### PR TITLE
Add the duration of each class under the time

### DIFF
--- a/frontend/src/features/class-list/components/ClassListItem.tsx
+++ b/frontend/src/features/class-list/components/ClassListItem.tsx
@@ -50,11 +50,19 @@ const ContentWrapper = styled.div`
   align-items: center;
 `;
 
-const Time = styled.div`
+const TimeWrapper = styled.div`
   margin-right: 8px;
   width: 80px;
+`;
+
+const Time = styled.div`
   font-weight: 600;
   color: ${(props) => props.theme.colors.main};
+`;
+
+const Duration = styled.div`
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.secondary};
 `;
 
 const Metadata = styled.div`
@@ -138,7 +146,10 @@ export const ClassListItem = ({ clazz }: Props) => {
     >
       <InteractiveCard $interactive={interactive}>
         <ContentWrapper>
-          <Time>{getLocalTime(clazz, studio?.timezone || "")} </Time>
+          <TimeWrapper>
+            <Time>{getLocalTime(clazz, studio?.timezone || "")} </Time>
+            <Duration>{clazz.duration / 60} mins</Duration>
+          </TimeWrapper>
           <InstructorIcon instructor={clazz.instructor} size={48} />
           <Metadata>
             <ClassTitle>{clazz.name}</ClassTitle>


### PR DESCRIPTION
I debated centering the text of the Time and Duration in the TimeWrapper, but decided on keeping them both left-aligned.

![Screenshot 2023-07-05 at 11 07 22 AM](https://github.com/Abbondanzo/peloton-reservations/assets/22065329/5beb42aa-7331-4a56-8ebe-26c73a9d48d4)
