### PR TITLE
Replace flexbox layout with sticky header

### DIFF
--- a/frontend/src/features/class-list/components/ClassListRoot.tsx
+++ b/frontend/src/features/class-list/components/ClassListRoot.tsx
@@ -6,12 +6,7 @@ import { useHydrateClassList } from "../hooks/useHydrateClassList";
 import { useSwipeToRefresh } from "../hooks/useSwipeToRefresh";
 import { ClassListWrapper } from "./ClassListWrapper";
 
-const BodyWrapper = styled.div`
-  flex: 1;
-  display: flex;
-  height: 100%;
-  min-height: 100%;
-`;
+const BodyWrapper = styled.div``;
 
 interface ToggleProps {
   $toggleVisible: boolean;
@@ -22,9 +17,12 @@ const SIDEBAR_WIDTH = 320;
 const Sidebar = styled.aside<ToggleProps>`
   max-width: 100%;
   width: ${SIDEBAR_WIDTH}px;
-  overflow: auto;
+  top: 60px;
+  bottom: 0;
+  overflow-y: auto;
   background-color: ${(props) => props.theme.colors.mainSurface};
   z-index: 1;
+  position: fixed;
 
   @media only screen and (max-width: ${(props) =>
       props.theme.widths.tablet}px) {
@@ -39,14 +37,15 @@ const Sidebar = styled.aside<ToggleProps>`
 
 const MainContent = styled.div<ToggleProps>`
   flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
   background-color: ${(props) => props.theme.colors.secondarySurface};
   padding: 16px;
   position: relative;
+  margin-left: ${SIDEBAR_WIDTH}px;
 
   @media only screen and (max-width: ${(props) =>
       props.theme.widths.tablet}px) {
+    margin-left: 0;
+
     &:before {
       content: "";
       position: fixed;
@@ -73,7 +72,7 @@ const SpinnerContainer = styled.div`
   padding-top: 10px;
   position: absolute;
   left: 0;
-  width: 100vw;
+  width: 100%;
   top: -${SPINNER_SIZE + 10}px;
   text-align: center;
 `;

--- a/frontend/src/features/navigation/components/MobileSidebar.tsx
+++ b/frontend/src/features/navigation/components/MobileSidebar.tsx
@@ -31,7 +31,7 @@ const SIDEBAR_WIDTH = 320;
 const SidebarWrapper = styled.div<ToggleProps>`
   display: flex;
   flex-direction: column;
-  position: absolute;
+  position: fixed;
   transition: right 0.25s;
   right: ${(props) => (props.$open ? 0 : -SIDEBAR_WIDTH)}px;
   top: 0;

--- a/frontend/src/features/navigation/components/NavbarProvider.tsx
+++ b/frontend/src/features/navigation/components/NavbarProvider.tsx
@@ -7,19 +7,18 @@ const HEIGHT = 60;
 const Wrapper = styled.div`
   height: 100%;
   min-height: 100%;
-  display: flex;
-  flex-direction: column;
 `;
 
 const NavWrapper = styled.div`
+  position: sticky;
   height: ${HEIGHT}px;
+  top: 0;
+  z-index: 1;
 `;
 
 const BodyWrapper = styled.div`
-  flex: 1;
-  height: calc(100% - ${HEIGHT}px);
   background-color: ${(props) => props.theme.colors.secondarySurface};
-  overflow-y: auto;
+  height: calc(100% - ${HEIGHT}px);
 `;
 
 interface Props {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,8 @@
 html,
 body,
 #root {
-  height: 100%;
-  position: relative;
-  overflow: hidden;
+  min-height: 100%;
+  background-color: #ededed;
 }
 
 body {


### PR DESCRIPTION
The layout computation is a bit of a mess due to the way we over-rely on overflow and flexboxes. Instead, this PR swaps out flexboxes with simple, flowing content and a sticky header positioned at the top of the page. The filter sidebar and navigation menus are both set to sticky positions