### PR TITLE
[fix] Respect iOS safe area insets on sidebars and overscroll background

### DIFF
--- a/frontend/src/features/class-list/components/ClassListRoot.tsx
+++ b/frontend/src/features/class-list/components/ClassListRoot.tsx
@@ -18,7 +18,7 @@ const SIDEBAR_WIDTH = 300;
 const Sidebar = styled.aside<ToggleProps>`
   max-width: 100%;
   width: ${SIDEBAR_WIDTH}px;
-  top: ${NAV_HEIGHT}px;
+  top: calc(${NAV_HEIGHT}px + env(safe-area-inset-top, 0px));
   bottom: 0;
   overflow-y: auto;
   background-color: ${(p) => p.theme.colors.secondarySurface};
@@ -31,7 +31,7 @@ const Sidebar = styled.aside<ToggleProps>`
     border-right: none;
     transition: left 0.25s;
     left: ${(p) => (p.$toggleVisible ? 0 : -SIDEBAR_WIDTH)}px;
-    top: 0;
+    top: calc(${NAV_HEIGHT}px + env(safe-area-inset-top, 0px));
     bottom: 0;
     z-index: 2;
     box-shadow: ${(p) =>

--- a/frontend/src/features/navigation/components/MobileSidebar.tsx
+++ b/frontend/src/features/navigation/components/MobileSidebar.tsx
@@ -43,8 +43,8 @@ const DrawerHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 16px;
-  height: 60px;
+  padding: env(safe-area-inset-top, 0) 16px 0;
+  height: calc(60px + env(safe-area-inset-top, 0px));
   background-color: ${NAV_BG};
   color: #fff;
   flex-shrink: 0;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,7 +6,6 @@ html {
 body,
 #root {
   min-height: 100%;
-  background-color: #ededed;
 }
 
 body {


### PR DESCRIPTION
- Filter sidebar: account for safe-area-inset-top in top offset so it
  doesn't extend behind the Dynamic Island on both desktop (fixed) and
  mobile (absolute) positioning
- Navigation sidebar: add safe-area-inset-top padding and height to the
  DrawerHeader so content clears the Dynamic Island while the dark
  background fills the safe area
- Pull-to-refresh: remove background-color from body/#root so the html
  element's dark navy (#181a2f) shows during overscroll instead of white

https://claude.ai/code/session_01Fiavf2KpJ2To2DaLNQnDN4