### PR TITLE
claude/fix-sidebar-safe-area-fi3Mh

### DIFF
--- a/frontend/src/features/class-list/components/ClassListRoot.tsx
+++ b/frontend/src/features/class-list/components/ClassListRoot.tsx
@@ -28,12 +28,9 @@ const Sidebar = styled.aside<ToggleProps>`
   position: fixed;
 
   @media only screen and (max-width: ${(p) => p.theme.widths.tablet}px) {
-    position: absolute;
     border-right: none;
     transition: left 0.25s;
     left: ${(p) => (p.$toggleVisible ? 0 : -SIDEBAR_WIDTH)}px;
-    top: calc(${NAV_HEIGHT}px + env(safe-area-inset-top, 0px));
-    bottom: 0;
     z-index: 2;
     box-shadow: ${(p) =>
       p.$toggleVisible ? "4px 0 16px rgba(0,0,0,0.08)" : "none"};

--- a/frontend/src/features/class-list/components/ClassListRoot.tsx
+++ b/frontend/src/features/class-list/components/ClassListRoot.tsx
@@ -20,6 +20,7 @@ const Sidebar = styled.aside<ToggleProps>`
   width: ${SIDEBAR_WIDTH}px;
   top: calc(${NAV_HEIGHT}px + env(safe-area-inset-top, 0px));
   bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   overflow-y: auto;
   background-color: ${(p) => p.theme.colors.secondarySurface};
   border-right: 1px solid ${(p) => p.theme.borderColor};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,13 @@
 html {
   height: 100%;
-  background-color: #181a2f;
+  background:
+    linear-gradient(
+      to bottom,
+      #181a2f 0,
+      #181a2f calc(60px + env(safe-area-inset-top, 0px)),
+      #ededed calc(60px + env(safe-area-inset-top, 0px))
+    )
+    fixed;
 }
 
 body,


### PR DESCRIPTION
- Filters sidebar now pads its scroll area with env(safe-area-inset-bottom)
  so content clears the iOS home indicator, mirroring the top inset handling.
- Replace the solid purple html background with a fixed gradient that is
  purple only across the nav band (nav height + top safe-area inset) and
  secondarySurface below. Prevents the nav color from bleeding through
  during initial paint, when content is short, or on bottom overscroll.

https://claude.ai/code/session_01UFhr4QpFCbpJ9GAAUVZBuf