### PR TITLE
Add custom alert names with auto-generated fallback titles

### DIFF
--- a/frontend/src/features/alerts/components/editor/AlertEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/AlertEditor.tsx
@@ -145,6 +145,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
     }
   }, [alertToEdit.studioId, dispatch]);
 
+  const [name, setName] = useState(alertToEdit.name || "");
   const [selectedInstructors, setSelectedInstructors] = useState<
     Optional<string[]>
   >(alertToEdit.instructors || null);
@@ -195,6 +196,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       id: alertToEdit.id || (null as any),
       created: alertToEdit.created || new Date().getTime(),
+      ...(name.trim() ? { name: name.trim() } : {}),
       studioId: selectedStudioId,
       instructors: selectedInstructors,
       disciplines: selectedDisciplines,
@@ -217,6 +219,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
   }, [
     alertToEdit.id,
     alertToEdit.created,
+    name,
     selectedStudioId,
     userId,
     selectedInstructors,
@@ -247,6 +250,8 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
       <StepContent>
         {currentStep === 0 && (
           <StepBasics
+            name={name}
+            onNameChange={setName}
             studioId={selectedStudioId}
             onStudioChange={(id) => dispatch(setStudioId(id))}
             maxStatus={maxStatus}
@@ -267,6 +272,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
         )}
         {currentStep === 3 && (
           <StepReview
+            name={name}
             studioId={selectedStudioId}
             maxStatus={maxStatus}
             selectedInstructors={selectedInstructors}

--- a/frontend/src/features/alerts/components/editor/StepBasics.tsx
+++ b/frontend/src/features/alerts/components/editor/StepBasics.tsx
@@ -2,6 +2,7 @@ import { STUDIOS } from "shared";
 import styled from "styled-components";
 import type { BookableStatus } from "../../../filters/types/BookableStatus";
 import { mediaMobile } from "../../../theme/constants/queries";
+import { TextInput } from "../../../theme/components/TextInput";
 import { OptionCard } from "./OptionCard";
 
 const Section = styled.fieldset`
@@ -67,6 +68,8 @@ const STATUS_OPTIONS: {
 ];
 
 interface Props {
+  name: string;
+  onNameChange: (name: string) => void;
   studioId: string;
   onStudioChange: (studioId: string) => void;
   maxStatus: BookableStatus;
@@ -74,6 +77,8 @@ interface Props {
 }
 
 export const StepBasics = ({
+  name,
+  onNameChange,
   studioId,
   onStudioChange,
   maxStatus,
@@ -81,6 +86,16 @@ export const StepBasics = ({
 }: Props) => {
   return (
     <div>
+      <TextInput
+        label="Alert name (optional)"
+        hint="Leave blank to auto-generate a name from your filters"
+        placeholder="e.g. Morning Cycling with Cody"
+        value={name}
+        onChange={onNameChange}
+      />
+
+      <SectionSpacer />
+
       <Section>
         <Legend>Which studio?</Legend>
         <Description>Pick the Peloton studio you want to monitor.</Description>

--- a/frontend/src/features/alerts/components/editor/StepReview.tsx
+++ b/frontend/src/features/alerts/components/editor/StepReview.tsx
@@ -105,6 +105,7 @@ const formatStatus = (status: BookableStatus): string => {
 };
 
 interface Props {
+  name: string;
   studioId: string;
   maxStatus: BookableStatus;
   selectedInstructors: Optional<string[]>;
@@ -113,6 +114,7 @@ interface Props {
 }
 
 export const StepReview = ({
+  name,
   studioId,
   maxStatus,
   selectedInstructors,
@@ -142,6 +144,13 @@ export const StepReview = ({
       </Description>
 
       <SummaryCard>
+        {name.trim() && (
+          <SummaryRow>
+            <RowLabel>Name</RowLabel>
+            <RowValue>{name.trim()}</RowValue>
+          </SummaryRow>
+        )}
+
         <SummaryRow>
           <RowLabel>Studio</RowLabel>
           <RowValue>{studio?.location || studioId}</RowValue>

--- a/frontend/src/features/alerts/components/list/AlertsListItem.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsListItem.tsx
@@ -8,6 +8,8 @@ import { border } from "../../../theme/constants/styles";
 import { DAY_NAMES } from "../../constants/days";
 import { deleteAlert } from "../../firebase/deleteAlert";
 import { isNotEmpty } from "../../../utils/optional";
+import { useGetInstructorsQuery, useGetDisciplinesQuery } from "../../../class-list/services/pelotonApi";
+import { generateAlertTitle } from "../../operators/generateAlertTitle";
 
 const Wrapper = styled.li`
   ${border}
@@ -49,7 +51,7 @@ const TitleRow = styled.div`
   flex-wrap: wrap;
 `;
 
-const StudioName = styled.span`
+const AlertTitle = styled.span`
   font-weight: 600;
   font-size: 15px;
   color: ${(props) => props.theme.colors.main};
@@ -81,18 +83,6 @@ const DetailRow = styled.div`
   flex-wrap: wrap;
   font-size: 13px;
   color: ${(props) => props.theme.colors.secondary};
-`;
-
-const DetailChip = styled.span`
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-`;
-
-const Dot = styled.span`
-  &::before {
-    content: "·";
-  }
 `;
 
 const DaysRow = styled.div`
@@ -195,6 +185,8 @@ interface Props {
 
 export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   const userId = useAppSelector(selectUserId);
+  const { data: allInstructors } = useGetInstructorsQuery(alert.studioId);
+  const { data: allDisciplines } = useGetDisciplinesQuery(alert.studioId);
 
   const formattedDate = useMemo(() => {
     const created = new Date(alert.created);
@@ -207,31 +199,28 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
     return formatter.format(alert.created);
   }, [alert.created]);
 
+  const alertTitle = useMemo(() => {
+    if (alert.name) return alert.name;
+
+    const instructorNames =
+      isNotEmpty(alert.instructors) && allInstructors
+        ? alert.instructors
+            .map((id) => allInstructors.find((i) => i.id === id)?.name)
+            .filter((n): n is string => Boolean(n))
+        : null;
+
+    const disciplineNames =
+      isNotEmpty(alert.disciplines) && allDisciplines
+        ? alert.disciplines
+            .map((id) => allDisciplines.find((d) => d.id === id)?.name)
+            .filter((n): n is string => Boolean(n))
+        : null;
+
+    return generateAlertTitle(disciplineNames, instructorNames);
+  }, [alert.name, alert.instructors, alert.disciplines, allInstructors, allDisciplines]);
+
   const studioLabel =
     STUDIOS[alert.studioId]?.location || alert.studioId || "No studio";
-
-  const instructorInfo = isNotEmpty(alert.instructors)
-    ? {
-        label:
-          alert.instructors.length === 1
-            ? "1 instructor"
-            : `${alert.instructors.length} instructors`,
-        title: `Filtering by ${alert.instructors.length} specific instructor${alert.instructors.length === 1 ? "" : "s"}`,
-      }
-    : {
-        label: "All instructors",
-        title: "Matching classes from any instructor",
-      };
-
-  const disciplineInfo = isNotEmpty(alert.disciplines)
-    ? {
-        label:
-          alert.disciplines.length === 1
-            ? "1 discipline"
-            : `${alert.disciplines.length} disciplines`,
-        title: `Filtering by ${alert.disciplines.length} specific discipline${alert.disciplines.length === 1 ? "" : "s"}`,
-      }
-    : { label: "All disciplines", title: "Matching any class type" };
 
   const statusInfo = formatStatus(alert.maxStatus);
 
@@ -240,21 +229,13 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
       <TopRow>
         <Info>
           <TitleRow>
-            <StudioName>{studioLabel}</StudioName>
+            <AlertTitle>{alertTitle}</AlertTitle>
             <StatusBadge $status={alert.maxStatus} title={statusInfo.title}>
               {statusInfo.label}
             </StatusBadge>
           </TitleRow>
 
-          <DetailRow>
-            <DetailChip title={instructorInfo.title}>
-              {instructorInfo.label}
-            </DetailChip>
-            <Dot />
-            <DetailChip title={disciplineInfo.title}>
-              {disciplineInfo.label}
-            </DetailChip>
-          </DetailRow>
+          <DetailRow>{studioLabel}</DetailRow>
 
           <DaysRow>
             {DAY_NAMES.map((day, i) => (

--- a/frontend/src/features/alerts/operators/generateAlertTitle.ts
+++ b/frontend/src/features/alerts/operators/generateAlertTitle.ts
@@ -1,0 +1,19 @@
+const formatList = (
+  names: string[] | null,
+  allLabel: string,
+  countSuffix: string
+): string => {
+  if (!names || names.length === 0) return allLabel;
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} or ${names[1]}`;
+  return `${names.length} ${countSuffix}`;
+};
+
+export const generateAlertTitle = (
+  disciplineNames: string[] | null,
+  instructorNames: string[] | null
+): string => {
+  const disciplinePart = formatList(disciplineNames, "Any Class", "Disciplines");
+  const instructorPart = formatList(instructorNames, "Any Instructor", "Instructors");
+  return `${disciplinePart} with ${instructorPart}`;
+};

--- a/shared/src/alerts.ts
+++ b/shared/src/alerts.ts
@@ -10,6 +10,7 @@ export interface TimeRange {
 export interface Alert {
   id: string;
   created: number;
+  name?: string;
   instructors: Optional<string[]>;
   disciplines: Optional<string[]>;
   maxStatus: BookableStatus;


### PR DESCRIPTION
Alerts now show a meaningful title derived from selected disciplines
and instructors (e.g. "Cycling with Cody Rigsby", "Any Class with 3
Instructors"). An optional custom name field in the editor overrides
the auto-generated title when set.

- Add `name?: string` to the Alert type in shared
- Add `generateAlertTitle` operator that formats discipline/instructor
  names into a human-readable title (shows up to 2 names, falls back
  to a count for 3+)
- Update AlertsListItem to resolve instructor/discipline names via RTK
  Query and display the generated (or custom) title prominently; the
  studio name moves to a secondary detail row
- Add an optional "Alert name" text input to StepBasics in the editor
- Show the custom name in StepReview when set

https://claude.ai/code/session_01NW69Qdz7jVvAJvBxTErgHY