### PR TITLE
[fix] Fix inverted timezone offset in alert time-range matching

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.16
+
+- Fixed time-range alert filtering incorrectly rejecting valid classes due to an inverted timezone offset. Classes were being shifted in the wrong direction when converting UTC timestamps to the studio's local timezone, causing day-of-week and time-of-day checks to fail
+
 ## 0.0.15
 
 - Fixed metrics for added and removed class counts not reliably persisting to the database. Writes were fire-and-forget with no error handling; low-frequency counters (e.g. one "added" event per day) could be silently dropped on a transient failure. Writes are now batched into a single `update()` call and properly awaited

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Backend comparison service for sending notifications",
   "scripts": {
     "build": "tsc",

--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -398,7 +398,7 @@ export class Alerter implements DiffDelegate {
       );
       const tzDate = new Date(date.toLocaleString("en-US", { timeZone }));
       const offset = utcDate.getTime() - tzDate.getTime();
-      date.setTime(date.getTime() + offset);
+      date.setTime(date.getTime() - offset);
       const range = alert.timeRanges[date.getDay()];
       if (!range) {
         return false;


### PR DESCRIPTION
The offset between UTC and studio local time was computed as `utcDate - tzDate` and then added to the class start time, which shifted the time in the wrong direction. For New York (UTC-4) a 7 AM class was being evaluated as if it were 3 PM, so every alert with timeRanges configured never matched and no notifications fired.

Flip the subtraction to `tzDate - utcDate` so the adjustment correctly moves the Date into studio local time before comparing against the user's day/time window.