### PR TITLE
[feat] Add support for selecting "All day" as the time range

### DIFF
--- a/frontend/src/features/alerts/components/editor/StepFilters.tsx
+++ b/frontend/src/features/alerts/components/editor/StepFilters.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { DisciplineIcon } from "../../../class-list/components/DisciplineIcon";
 import { InstructorIcon } from "../../../class-list/components/InstructorIcon";
@@ -131,6 +132,33 @@ export const StepFilters = ({
 }: Props) => {
   const instructorsQuery = useGetInstructorsQuery(studioId);
   const disciplinesQuery = useGetDisciplinesQuery(studioId);
+
+  // Reconcile stale IDs (e.g. a saved instructor who left the studio) against
+  // the loaded list once per mount. Uses a ref so user edits don't re-trigger it.
+  const initialInstructors = useRef(selectedInstructors);
+  const initialDisciplines = useRef(selectedDisciplines);
+
+  useEffect(() => {
+    const initial = initialInstructors.current;
+    if (!instructorsQuery.currentData || !isNotEmpty(initial)) return;
+    const valid = new Set(instructorsQuery.currentData.map((i) => i.id));
+    const filtered = initial.filter((id) => valid.has(id));
+    if (filtered.length < initial.length) {
+      setSelectedInstructors(filtered);
+      initialInstructors.current = filtered;
+    }
+  }, [instructorsQuery.currentData, setSelectedInstructors]);
+
+  useEffect(() => {
+    const initial = initialDisciplines.current;
+    if (!disciplinesQuery.currentData || !isNotEmpty(initial)) return;
+    const valid = new Set(disciplinesQuery.currentData.map((d) => String(d.id)));
+    const filtered = initial.filter((id) => valid.has(String(id)));
+    if (filtered.length < initial.length) {
+      setSelectedDisciplines(filtered);
+      initialDisciplines.current = filtered;
+    }
+  }, [disciplinesQuery.currentData, setSelectedDisciplines]);
 
   const toggleInstructor = (id: string) => {
     if (!isNotEmpty(selectedInstructors)) return;

--- a/frontend/src/features/alerts/components/editor/StepReview.tsx
+++ b/frontend/src/features/alerts/components/editor/StepReview.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import type { BookableStatus } from "../../../filters/types/BookableStatus";
 import { mediaMobile } from "../../../theme/constants/queries";
 import { DAY_NAMES } from "../../constants/days";
-import { TIME_RANGE_VALUES } from "../../constants/timeRanges";
+import { TIME_RANGE_VALUES, isAllDay } from "../../constants/timeRanges";
 
 const Section = styled.fieldset`
   border: none;
@@ -87,6 +87,7 @@ const DayChip = styled.span`
 `;
 
 const formatTimeRange = (tr: TimeRange): string => {
+  if (isAllDay(tr)) return "All day";
   const start = TIME_RANGE_VALUES.find((v) => v.minutes === tr.startMin);
   const end = TIME_RANGE_VALUES.find((v) => v.minutes === tr.endMin);
   if (!start || !end) return "All day";

--- a/frontend/src/features/alerts/components/editor/StepSchedule.tsx
+++ b/frontend/src/features/alerts/components/editor/StepSchedule.tsx
@@ -1,12 +1,15 @@
-import { type ChangeEvent, useCallback } from "react";
+import { type ChangeEvent, useCallback, useRef } from "react";
 import type { TimeRange } from "shared";
 import styled from "styled-components";
 import { mediaMobile } from "../../../theme/constants/queries";
 import { border } from "../../../theme/constants/styles";
 import { DAY_NAMES } from "../../constants/days";
 import {
+  ALL_DAY_TIME_RANGE,
   DEFAULT_TIME_RANGE,
+  SPECIFIC_DEFAULT_TIME_RANGE,
   TIME_RANGE_VALUES,
+  isAllDay,
 } from "../../constants/timeRanges";
 
 const Section = styled.fieldset`
@@ -39,6 +42,8 @@ const DayRow = styled.div<{ $enabled: boolean }>`
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
+  min-height: 52px;
+  box-sizing: border-box;
   border-radius: ${(props) => props.theme.borderRadius};
   background-color: ${(props) =>
     props.$enabled ? `${props.theme.colors.accent}06` : "transparent"};
@@ -50,6 +55,7 @@ const DayRow = styled.div<{ $enabled: boolean }>`
   ${mediaMobile`
     flex-wrap: wrap;
     gap: 8px;
+    min-height: 0;
   `}
 `;
 
@@ -83,6 +89,21 @@ const TimeControls = styled.div`
     margin-left: 28px;
     width: calc(100% - 28px);
   `}
+`;
+
+const AllDayLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: ${(props) => props.theme.colors.secondary};
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+`;
+
+const AllDayCheckbox = styled.input`
+  accent-color: ${(props) => props.theme.colors.accent};
 `;
 
 const TimeSelect = styled.select`
@@ -136,11 +157,31 @@ interface Props {
 
 export const StepSchedule = ({ timeRanges, setTimeRanges }: Props) => {
   const enabledCount = timeRanges.filter(Boolean).length;
+  const lastSpecificRanges = useRef<(TimeRange | undefined)[]>(
+    DAY_NAMES.map(() => undefined)
+  );
 
   const toggleDay = useCallback(
     (index: number) => {
       const updated = [...timeRanges];
       updated[index] = updated[index] ? null : DEFAULT_TIME_RANGE;
+      setTimeRanges(updated);
+    },
+    [timeRanges, setTimeRanges]
+  );
+
+  const toggleAllDay = useCallback(
+    (index: number) => {
+      const current = timeRanges[index];
+      if (!current) return;
+      const updated = [...timeRanges];
+      if (isAllDay(current)) {
+        updated[index] =
+          lastSpecificRanges.current[index] ?? SPECIFIC_DEFAULT_TIME_RANGE;
+      } else {
+        lastSpecificRanges.current[index] = current;
+        updated[index] = ALL_DAY_TIME_RANGE;
+      }
       setTimeRanges(updated);
     },
     [timeRanges, setTimeRanges]
@@ -209,6 +250,7 @@ export const StepSchedule = ({ timeRanges, setTimeRanges }: Props) => {
       <DayGrid>
         {DAY_NAMES.map((day, index) => {
           const timeRange = timeRanges[index];
+          const dayIsAllDay = !!timeRange && isAllDay(timeRange);
           return (
             <DayRow key={day} $enabled={!!timeRange}>
               <DayLabel htmlFor={`day-${index}`}>
@@ -223,43 +265,61 @@ export const StepSchedule = ({ timeRanges, setTimeRanges }: Props) => {
 
               {timeRange && (
                 <TimeControls>
-                  <TimeSelect
-                    value={timeRange.startMin}
-                    aria-label={`${day} start time`}
-                    onChange={({ target }: ChangeEvent<HTMLSelectElement>) => {
-                      const mins = parseInt(target.value);
-                      if (!Number.isNaN(mins))
-                        updateTime(index, "startMin", mins);
-                    }}
-                  >
-                    {TIME_RANGE_VALUES.map((v) => (
-                      <option key={v.minutes} value={v.minutes}>
-                        {v.label}
-                      </option>
-                    ))}
-                  </TimeSelect>
-                  <ToLabel>to</ToLabel>
-                  <TimeSelect
-                    value={timeRange.endMin}
-                    aria-label={`${day} end time`}
-                    onChange={({ target }: ChangeEvent<HTMLSelectElement>) => {
-                      const mins = parseInt(target.value);
-                      if (!Number.isNaN(mins))
-                        updateTime(index, "endMin", mins);
-                    }}
-                  >
-                    {TIME_RANGE_VALUES.map((v) => (
-                      <option
-                        key={v.minutes}
-                        value={v.minutes}
-                        disabled={
-                          v.minutes > 0 && v.minutes < timeRange.startMin
-                        }
+                  <AllDayLabel htmlFor={`allday-${index}`}>
+                    <AllDayCheckbox
+                      type="checkbox"
+                      id={`allday-${index}`}
+                      checked={dayIsAllDay}
+                      onChange={() => toggleAllDay(index)}
+                    />
+                    All day
+                  </AllDayLabel>
+
+                  {!dayIsAllDay && (
+                    <>
+                      <TimeSelect
+                        value={timeRange.startMin}
+                        aria-label={`${day} start time`}
+                        onChange={({
+                          target,
+                        }: ChangeEvent<HTMLSelectElement>) => {
+                          const mins = parseInt(target.value);
+                          if (!Number.isNaN(mins))
+                            updateTime(index, "startMin", mins);
+                        }}
                       >
-                        {v.label}
-                      </option>
-                    ))}
-                  </TimeSelect>
+                        {TIME_RANGE_VALUES.map((v) => (
+                          <option key={v.minutes} value={v.minutes}>
+                            {v.label}
+                          </option>
+                        ))}
+                      </TimeSelect>
+                      <ToLabel>to</ToLabel>
+                      <TimeSelect
+                        value={timeRange.endMin}
+                        aria-label={`${day} end time`}
+                        onChange={({
+                          target,
+                        }: ChangeEvent<HTMLSelectElement>) => {
+                          const mins = parseInt(target.value);
+                          if (!Number.isNaN(mins))
+                            updateTime(index, "endMin", mins);
+                        }}
+                      >
+                        {TIME_RANGE_VALUES.map((v) => (
+                          <option
+                            key={v.minutes}
+                            value={v.minutes}
+                            disabled={
+                              v.minutes > 0 && v.minutes < timeRange.startMin
+                            }
+                          >
+                            {v.label}
+                          </option>
+                        ))}
+                      </TimeSelect>
+                    </>
+                  )}
                 </TimeControls>
               )}
             </DayRow>

--- a/frontend/src/features/alerts/constants/timeRanges.ts
+++ b/frontend/src/features/alerts/constants/timeRanges.ts
@@ -1,9 +1,20 @@
 import type { TimeRange } from "shared";
 
-export const DEFAULT_TIME_RANGE: TimeRange = {
+export const ALL_DAY_TIME_RANGE: TimeRange = {
+  startMin: 0,
+  endMin: 24 * 60,
+};
+
+export const SPECIFIC_DEFAULT_TIME_RANGE: TimeRange = {
   startMin: 7 * 60,
   endMin: 19 * 60,
 };
+
+export const DEFAULT_TIME_RANGE: TimeRange = ALL_DAY_TIME_RANGE;
+
+export const isAllDay = (range: TimeRange): boolean =>
+  range.startMin === ALL_DAY_TIME_RANGE.startMin &&
+  range.endMin === ALL_DAY_TIME_RANGE.endMin;
 
 interface Value {
   minutes: number;


### PR DESCRIPTION
Users must currently specify a time range for their alerts (defaults 7a to 7p) but classes can be added outside of that range and to someone who is tolerant of early/later classes, it would make more sense to have "All day" as an option