### PR TITLE
[feat] Route notification clicks to the specific Peloton class URL

### DIFF
--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -233,7 +233,9 @@ export class Alerter implements DiffDelegate {
           requireInteraction: true,
         },
         fcmOptions: {
-          link: pending.classData.customer_url || "/",
+          link: pending.classData.customer_url
+            ? `/?classUrl=${encodeURIComponent(pending.classData.customer_url)}`
+            : "/",
         },
       },
     };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Provider } from "react-redux";
 import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
@@ -8,6 +9,18 @@ import { store } from "./features/store/constants/store";
 import { theme } from "./features/theme/constants/theme";
 
 function App() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const classUrl = params.get("classUrl");
+    if (!classUrl) return;
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + window.location.hash
+    );
+    window.location.assign(classUrl);
+  }, []);
+
   return (
     <ThemeProvider theme={theme}>
       <Provider store={store}>

--- a/frontend/src/messaging-sw.ts
+++ b/frontend/src/messaging-sw.ts
@@ -75,7 +75,29 @@ if (app) {
       });
       if (windowClients.some((c) => c.visibilityState === "visible")) return;
     }
-    self.registration.showNotification(title, { body });
+    self.registration.showNotification(title, { body, data: payload.data });
+  });
+
+  self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+    const classUrl: string | undefined = event.notification.data?.classUrl;
+    const appUrl = classUrl
+      ? `/?classUrl=${encodeURIComponent(classUrl)}`
+      : "/";
+    event.waitUntil(
+      self.clients
+        .matchAll({ type: "window", includeUncontrolled: true })
+        .then((windowClients) => {
+          const appClient = windowClients.find(
+            (c) => new URL(c.url).origin === self.location.origin
+          );
+          if (appClient) {
+            (appClient as WindowClient).navigate(appUrl);
+            return (appClient as WindowClient).focus();
+          }
+          return self.clients.openWindow(appUrl);
+        })
+    );
   });
 }
 


### PR DESCRIPTION
When a push notification is clicked, encode the class booking URL as a
?classUrl= query param in fcmOptions.link so the PWA opens and immediately
redirects to the right class. The service worker notificationclick handler
covers the data-only iOS path with the same logic.

https://claude.ai/code/session_01JijrM6Vmr4683me8wDpc8X