### PR TITLE
Fix mobile PWA safe area background and bottom padding

### DIFF
--- a/frontend/src/features/class-list/components/ClassListRoot.tsx
+++ b/frontend/src/features/class-list/components/ClassListRoot.tsx
@@ -41,6 +41,7 @@ const MainContent = styled.div<ToggleProps>`
   flex: 1;
   background-color: ${(p) => p.theme.colors.secondarySurface};
   padding: 20px;
+  padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
   position: relative;
   margin-left: ${SIDEBAR_WIDTH}px;
 
@@ -64,6 +65,7 @@ const MainContent = styled.div<ToggleProps>`
 
   @media only screen and (max-width: ${(p) => p.theme.widths.mobile}px) {
     padding: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   }
 `;
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,6 +16,7 @@ body,
 
 body {
   margin: 0;
+  background-color: #ededed;
   font-family:
     "Inter",
     -apple-system,


### PR DESCRIPTION
Adds background-color to body so the unsafe zone shows #ededed instead
of white during loading. Adds env(safe-area-inset-bottom) to MainContent
padding so the last class item isn't clipped by the home indicator.

https://claude.ai/code/session_01Ccn6BGGeWdjPxuq84gtPBt