### PR TITLE
Fix notification routing to open the correct class URL

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.18
+
+- Push notifications now link directly to the Peloton class booking page instead of the app root. Added a `frontend_url` add-on option (set it to your hosted app URL, e.g. `https://abbondanzo.github.io/peloton-reservations`) so the notification click lands on the correct subpath and immediately redirects to the class
+
 ## 0.0.17
 
 - Added class history storage: the backend now writes snapshots to Firebase (`classHistory/{studioId}/{classId}`) whenever a class first appears or its bookable status changes (free ↔ waitlist ↔ full). Snapshots are retained for 7 days via an hourly cleanup job

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,5 +1,5 @@
 name: Peloton Reservations
-version: "0.0.17"
+version: "0.0.18"
 image: ghcr.io/abbondanzo/peloton-reservations
 slug: peloton_reservations
 description: Polls Peloton studio schedules and sends class availability alerts

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -15,6 +15,8 @@ map:
 options:
   firebase_credentials: ""
   sentry_dsn: ""
+  frontend_url: ""
 schema:
   firebase_credentials: password
   sentry_dsn: str?
+  frontend_url: str?

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Backend comparison service for sending notifications",
   "scripts": {
     "build": "tsc",

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -17,6 +17,12 @@ if [ -n "$SENTRY_DSN" ]; then
   export SENTRY_DSN
 fi
 
+# Optionally export frontend URL if configured in add-on options
+FRONTEND_URL=$(node -e "try { const o = JSON.parse(require('fs').readFileSync('/data/options.json','utf8')); process.stdout.write(o.frontend_url||''); } catch(e) {}")
+if [ -n "$FRONTEND_URL" ]; then
+  export FRONTEND_URL
+fi
+
 export DATA_DIR=/data
 
 cd /app/backend

--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -21,6 +21,15 @@ import { Metrics } from "./metrics";
 
 type StudioGroup = { [key: string]: Alert[] };
 
+// Trailing slash stripped so we can append "/?classUrl=..." cleanly.
+const FRONTEND_URL = (process.env.FRONTEND_URL ?? "").replace(/\/$/, "");
+
+function buildNotificationLink(classUrl: string | null | undefined): string {
+  const base = FRONTEND_URL || "/";
+  if (!classUrl) return base;
+  return `${FRONTEND_URL}/?classUrl=${encodeURIComponent(classUrl)}`;
+}
+
 /** How often to flush the pending-notification queue. */
 const PENDING_CHECK_INTERVAL_MS = 30 * 1000;
 /** How long to retain class history snapshots. */
@@ -248,9 +257,7 @@ export class Alerter implements DiffDelegate {
           requireInteraction: true,
         },
         fcmOptions: {
-          link: pending.classData.customer_url
-            ? `/?classUrl=${encodeURIComponent(pending.classData.customer_url)}`
-            : "/",
+          link: buildNotificationLink(pending.classData.customer_url),
         },
       },
     };

--- a/backend/translations/en.yaml
+++ b/backend/translations/en.yaml
@@ -10,3 +10,10 @@ configuration:
     description: >-
       Optional. Paste your Sentry DSN here to enable error reporting.
       Leave blank to disable Sentry.
+  frontend_url:
+    name: Frontend URL
+    description: >-
+      Optional. The base URL where the frontend is hosted (e.g.
+      https://abbondanzo.github.io/peloton-reservations). When set, push
+      notification clicks will open the app at this URL and redirect directly
+      to the relevant class booking page. Leave blank to disable deep linking.

--- a/frontend/src/messaging-sw.ts
+++ b/frontend/src/messaging-sw.ts
@@ -80,10 +80,12 @@ if (app) {
 
   self.addEventListener("notificationclick", (event) => {
     event.notification.close();
+    const swPathname = self.location.pathname;
+    const basePath = swPathname.substring(0, swPathname.lastIndexOf("/") + 1);
     const classUrl: string | undefined = event.notification.data?.classUrl;
     const appUrl = classUrl
-      ? `/?classUrl=${encodeURIComponent(classUrl)}`
-      : "/";
+      ? `${basePath}?classUrl=${encodeURIComponent(classUrl)}`
+      : basePath;
     event.waitUntil(
       self.clients
         .matchAll({ type: "window", includeUncontrolled: true })


### PR DESCRIPTION
## Summary

- Push notifications now route to the specific Peloton class booking page instead of the app root
- `fcmOptions.link` encodes the class URL as a `?classUrl=` query param; the frontend reads it on load and redirects
- Added `frontend_url` add-on option so the notification link resolves to the correct subpath (e.g. `https://abbondanzo.github.io/peloton-reservations`) rather than the root domain
- Service worker `notificationclick` handler derives the base path from `self.location` instead of hardcoding `/`

## Test plan

- [ ] Set `frontend_url` to `https://abbondanzo.github.io/peloton-reservations` in the add-on Configuration tab
- [ ] Trigger a test notification and confirm clicking it opens the app at the correct subpath
- [ ] Confirm the app immediately redirects to the Peloton class booking page
- [ ] Confirm that notifications without a `classUrl` (no booking URL) still open the app root cleanly

https://claude.ai/code/session_01JijrM6Vmr4683me8wDpc8X