### PR TITLE
Fix notification URL resolving relative customer_url against app origin

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,9 @@ function App() {
       "",
       window.location.pathname + window.location.hash
     );
-    window.location.assign(classUrl);
+    window.location.assign(
+      new URL(classUrl, "https://schedule.studio.onepeloton.com").href
+    );
   }, []);
 
   return (


### PR DESCRIPTION
Peloton's API returns customer_url as a relative path (e.g.
/p/7248695-peloton-studios-new-york/e/99586855-30-min-intervals-ride/).
window.location.assign() was resolving it against the app's own origin
(abbondanzo.github.io) instead of Peloton's. Resolve against
schedule.studio.onepeloton.com, matching the pattern in ClassListItem.tsx.

https://claude.ai/code/session_017fczStuR4yzeqLjc4ECVMs