### PR TITLE
[fix] Fix swipe-to-refresh spinner animation and add timeout guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,12 @@ Types are defined in `shared/src/alerts.ts` and `frontend/src/features/`. Look t
 - `React.memo` on `ClassListItem`, `AlertsListItem`
 
 ## Git & PR Conventions
-- PR titles must use semantic prefixes: `[feat]`, `[fix]`, `[chore]`, `[refactor]`, `[docs]`, `[test]`, `[style]`
-- Example: `[fix] Fix navbar overlapping sticky alert simulation day headers`
+Both commit messages and PR titles must use the same semantic prefix format: `[feat]`, `[fix]`, `[chore]`, `[refactor]`, `[docs]`, `[test]`, `[style]`
+
+- Commit example: `[fix] Fix navbar overlapping sticky alert simulation day headers`
+- PR title example: `[fix] Fix navbar overlapping sticky alert simulation day headers`
+
+When running `gh pr create`, always include the prefix in the `--title` argument, e.g. `--title "[fix] Fix PWA pull-to-refresh spinner getting stuck"`.
 
 ## Gotchas
 - Vite `preserveSymlinks: true` + pnpm causes duplicate React — fixed with `resolve.dedupe: ["react", "react-dom"]` in vite.config.ts

--- a/frontend/src/features/class-list/components/ClassListRoot.tsx
+++ b/frontend/src/features/class-list/components/ClassListRoot.tsx
@@ -91,7 +91,7 @@ const Spinner = styled.div`
   --sp-color: ${(p) => p.theme.colors.accent};
 
   &.animate div {
-    animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1);
+    animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
     border-color: var(--sp-color) transparent transparent transparent;
   }
 

--- a/frontend/src/features/class-list/hooks/useSwipeToRefresh.ts
+++ b/frontend/src/features/class-list/hooks/useSwipeToRefresh.ts
@@ -101,13 +101,22 @@ export const useSwipeToRefresh = ({ refresh }: Options) => {
           el.style.opacity = "1";
         }
 
-        refresh().finally(() => {
+        let settled = false;
+        const hideSpinner = () => {
+          if (settled) return;
+          settled = true;
           isRefreshing = false;
           const el = spinnerRef.current;
           if (el) {
             el.classList.remove("animate");
             resetSpinner(true);
           }
+        };
+        // Guard against refresh() never settling (e.g. network hang)
+        const timeoutId = setTimeout(hideSpinner, 10_000);
+        refresh().finally(() => {
+          clearTimeout(timeoutId);
+          hideSpinner();
         });
       } else {
         shouldRefresh = false;


### PR DESCRIPTION
## Summary
This PR fixes the swipe-to-refresh functionality by ensuring the loading spinner animates continuously and adding a safety timeout to prevent the spinner from getting stuck if the refresh request never completes.

## Key Changes
- **Added infinite animation to spinner**: Fixed the CSS animation to include `infinite` keyword so the spinner continuously loops instead of playing once
- **Added timeout guard for refresh requests**: Implemented a 10-second timeout that will hide the spinner even if the `refresh()` promise never settles, preventing the UI from getting stuck in a loading state during network hangs
- **Prevented duplicate cleanup**: Added a `settled` flag to ensure the spinner cleanup logic only runs once, whether triggered by the timeout or the refresh promise completing

## Implementation Details
- The `hideSpinner` function now checks the `settled` flag before executing cleanup logic
- A 10-second timeout is set when refresh begins and cleared when the refresh promise settles
- This provides a graceful fallback for edge cases where network requests hang indefinitely

https://claude.ai/code/session_015UbknwVJxpMTCQnRugxmZ3