### PR TITLE
[refactor] Refactor React best practices: memoization, stable callbacks, and component separation

### DIFF
--- a/frontend/src/features/alerts/components/editor/AlertEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/AlertEditor.tsx
@@ -1,16 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { type Alert, DEFAULT_STUDIO_ID, type TimeRange } from "shared";
+import { useCallback, useState } from "react";
+import { type Alert } from "shared";
 import styled from "styled-components";
 import { captureException } from "@sentry/react";
-import { getStoredStudioId } from "../../../class-list/operators/studioStorage";
-import { selectStudioId } from "../../../class-list/selectors/selectStudioId";
 import { setStudioId } from "../../../class-list/slices/studioSlice";
-import type { BookableStatus } from "../../../filters/types/BookableStatus";
 import { selectUserId } from "../../../session/selectors/selectUserId";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks/useStore";
 import { mediaMobile } from "../../../theme/constants/queries";
-import { DAY_NAMES } from "../../constants/days";
-import { DEFAULT_TIME_RANGE } from "../../constants/timeRanges";
 import { addAlert } from "../../firebase/addAlert";
 import { editAlert } from "../../firebase/editAlert";
 import { StepBasics } from "./StepBasics";
@@ -18,6 +13,7 @@ import { StepFilters } from "./StepFilters";
 import { StepIndicator } from "./StepIndicator";
 import { StepReview } from "./StepReview";
 import { StepSchedule } from "./StepSchedule";
+import { useAlertEditorState } from "./useAlertEditorState";
 
 const STEPS = ["Basics", "Filters", "Schedule", "Review"];
 
@@ -128,52 +124,26 @@ interface Props {
 
 export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
   const dispatch = useAppDispatch();
-  const selectedStudioId = useAppSelector(selectStudioId);
   const userId = useAppSelector(selectUserId);
 
-  // --- Step state ---
   const [currentStep, setCurrentStep] = useState(0);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
 
-  // --- Form state ---
-  useEffect(() => {
-    if (alertToEdit.studioId) {
-      dispatch(setStudioId(alertToEdit.studioId));
-    } else {
-      dispatch(setStudioId(getStoredStudioId(DEFAULT_STUDIO_ID)));
-    }
-  }, [alertToEdit.studioId, dispatch]);
+  const {
+    selectedStudioId,
+    name,
+    setName,
+    selectedInstructors,
+    setSelectedInstructors,
+    selectedDisciplines,
+    setSelectedDisciplines,
+    timeRanges,
+    setTimeRanges,
+    maxStatus,
+    setMaxStatus,
+  } = useAlertEditorState(alertToEdit);
 
-  const [name, setName] = useState(alertToEdit.name || "");
-  const [selectedInstructors, setSelectedInstructors] = useState<
-    Optional<string[]>
-  >(alertToEdit.instructors || null);
-  const [selectedDisciplines, setSelectedDisciplines] = useState<
-    Optional<string[]>
-  >(alertToEdit.disciplines || null);
-  const [timeRanges, setTimeRanges] = useState<Optional<TimeRange>[]>(
-    () => alertToEdit.timeRanges || DAY_NAMES.map(() => DEFAULT_TIME_RANGE)
-  );
-  const [maxStatus, setMaxStatus] = useState<BookableStatus>(
-    alertToEdit.maxStatus || "free"
-  );
-
-  // Reset filters when studio changes
-  const lastStudioRef = useRef<string | undefined>(alertToEdit.studioId);
-  useEffect(() => {
-    if (
-      selectedStudioId &&
-      lastStudioRef.current &&
-      selectedStudioId !== lastStudioRef.current
-    ) {
-      setSelectedInstructors((cur) => (cur ? [] : cur));
-      setSelectedDisciplines((cur) => (cur ? [] : cur));
-    }
-    lastStudioRef.current = selectedStudioId;
-  }, [selectedStudioId]);
-
-  // --- Navigation ---
   const canGoNext = currentStep < STEPS.length - 1;
   const canGoBack = currentStep > 0;
   const isReview = currentStep === STEPS.length - 1;
@@ -186,7 +156,6 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
     if (canGoBack) setCurrentStep((s) => s - 1);
   }, [canGoBack]);
 
-  // --- Save ---
   const handleSave = useCallback(async () => {
     if (!selectedStudioId || !userId) return;
     setSaving(true);

--- a/frontend/src/features/alerts/components/editor/RegisteredDevicesEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/RegisteredDevicesEditor.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { memo, useCallback, useContext, useMemo } from "react";
 import styled from "styled-components";
 import { MessagingContext } from "../../../messaging/context/MessagingContext";
 import { RegisteredDevicesContext } from "../../../messaging/context/RegisteredDevicesContext";
@@ -132,12 +132,13 @@ const getDeviceIcon = (ua?: string): string => {
 };
 
 interface DeviceItemProps {
+  deviceToken: string;
   device: RegisteredDevice;
   isCurrentDevice: boolean;
-  onDelete: () => void;
+  onDelete: (token: string) => void;
 }
 
-const DeviceItem = ({ device, isCurrentDevice, onDelete }: DeviceItemProps) => {
+const DeviceItem = memo(({ deviceToken, device, isCurrentDevice, onDelete }: DeviceItemProps) => {
   const formattedDate = useMemo(() => {
     const date = new Date(device.timestamp);
     const isThisYear = date.getFullYear() === new Date().getFullYear();
@@ -165,14 +166,14 @@ const DeviceItem = ({ device, isCurrentDevice, onDelete }: DeviceItemProps) => {
       </DeviceInfo>
       <RemoveButton
         type="button"
-        onClick={onDelete}
+        onClick={() => onDelete(deviceToken)}
         aria-label={`Remove ${friendlyName}`}
       >
         Remove
       </RemoveButton>
     </ItemWrapper>
   );
-};
+});
 
 interface DevicesListProps {
   devices: [string, RegisteredDevice][];
@@ -183,11 +184,11 @@ const RegisteredDevicesList = ({ devices }: DevicesListProps) => {
   const currentDevice = messaging.token;
 
   const userId = useAppSelector(selectUserId);
-  const onDelete = (deviceToken: string) => {
+  const onDelete = useCallback((deviceToken: string) => {
     if (userId) {
       deleteToken(userId, deviceToken).catch(console.error);
     }
-  };
+  }, [userId]);
 
   if (devices.length === 0) {
     return (
@@ -200,6 +201,7 @@ const RegisteredDevicesList = ({ devices }: DevicesListProps) => {
       {devices.map(([deviceToken, device]) => (
         <DeviceItem
           key={deviceToken}
+          deviceToken={deviceToken}
           device={device}
           isCurrentDevice={
             currentDevice !== undefined
@@ -207,7 +209,7 @@ const RegisteredDevicesList = ({ devices }: DevicesListProps) => {
               : device.userAgent !== undefined &&
                 device.userAgent === navigator.userAgent
           }
-          onDelete={() => onDelete(deviceToken)}
+          onDelete={onDelete}
         />
       ))}
     </ListWrapper>

--- a/frontend/src/features/alerts/components/editor/StepFilters.tsx
+++ b/frontend/src/features/alerts/components/editor/StepFilters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { DisciplineIcon } from "../../../class-list/components/DisciplineIcon";
 import { InstructorIcon } from "../../../class-list/components/InstructorIcon";
@@ -162,25 +162,31 @@ export const StepFilters = ({
     }
   }, [disciplinesQuery.currentData, setSelectedDisciplines]);
 
-  const toggleInstructor = (id: string) => {
-    if (!isNotEmpty(selectedInstructors)) return;
-    const has = selectedInstructors.includes(id);
-    setSelectedInstructors(
-      has
-        ? selectedInstructors.filter((i) => i !== id)
-        : [...selectedInstructors, id]
-    );
-  };
+  const toggleInstructor = useCallback(
+    (id: string) => {
+      if (!isNotEmpty(selectedInstructors)) return;
+      const has = selectedInstructors.includes(id);
+      setSelectedInstructors(
+        has
+          ? selectedInstructors.filter((i) => i !== id)
+          : [...selectedInstructors, id]
+      );
+    },
+    [selectedInstructors, setSelectedInstructors]
+  );
 
-  const toggleDiscipline = (id: string) => {
-    if (!isNotEmpty(selectedDisciplines)) return;
-    const has = selectedDisciplines.includes(id);
-    setSelectedDisciplines(
-      has
-        ? selectedDisciplines.filter((d) => d !== id)
-        : [...selectedDisciplines, id]
-    );
-  };
+  const toggleDiscipline = useCallback(
+    (id: string) => {
+      if (!isNotEmpty(selectedDisciplines)) return;
+      const has = selectedDisciplines.includes(id);
+      setSelectedDisciplines(
+        has
+          ? selectedDisciplines.filter((d) => d !== id)
+          : [...selectedDisciplines, id]
+      );
+    },
+    [selectedDisciplines, setSelectedDisciplines]
+  );
 
   const isFilteringInstructors = isNotEmpty(selectedInstructors);
   const isFilteringDisciplines = isNotEmpty(selectedDisciplines);
@@ -272,7 +278,7 @@ interface InstructorsListProps {
   onToggle: (id: string) => void;
 }
 
-const InstructorsList = ({
+const InstructorsList = memo(({
   query,
   selectedIds,
   onToggle,
@@ -284,7 +290,7 @@ const InstructorsList = ({
     return (
       <ErrorText>
         Couldn't load instructors.{" "}
-        <RetryButton type="button" onClick={() => query.refetch()}>
+        <RetryButton type="button" onClick={query.refetch}>
           Try again
         </RetryButton>
       </ErrorText>
@@ -307,7 +313,7 @@ const InstructorsList = ({
       ))}
     </Grid>
   );
-};
+});
 
 interface DisciplinesListProps {
   query: ReturnType<typeof useGetDisciplinesQuery>;
@@ -315,7 +321,7 @@ interface DisciplinesListProps {
   onToggle: (id: string) => void;
 }
 
-const DisciplinesList = ({
+const DisciplinesList = memo(({
   query,
   selectedIds,
   onToggle,
@@ -327,7 +333,7 @@ const DisciplinesList = ({
     return (
       <ErrorText>
         Couldn't load disciplines.{" "}
-        <RetryButton type="button" onClick={() => query.refetch()}>
+        <RetryButton type="button" onClick={query.refetch}>
           Try again
         </RetryButton>
       </ErrorText>
@@ -350,4 +356,4 @@ const DisciplinesList = ({
       ))}
     </Grid>
   );
-};
+});

--- a/frontend/src/features/alerts/components/editor/StepSchedule.tsx
+++ b/frontend/src/features/alerts/components/editor/StepSchedule.tsx
@@ -208,20 +208,20 @@ export const StepSchedule = ({ timeRanges, setTimeRanges }: Props) => {
     [timeRanges, setTimeRanges]
   );
 
-  const selectAll = () => {
+  const selectAll = useCallback(() => {
     setTimeRanges(DAY_NAMES.map(() => DEFAULT_TIME_RANGE));
-  };
+  }, [setTimeRanges]);
 
-  const clearAll = () => {
+  const clearAll = useCallback(() => {
     setTimeRanges(DAY_NAMES.map(() => null));
-  };
+  }, [setTimeRanges]);
 
-  const copyFirstToAll = () => {
+  const copyFirstToAll = useCallback(() => {
     const first = timeRanges.find(Boolean);
     if (first) {
       setTimeRanges(timeRanges.map((tr) => (tr ? { ...first } : null)));
     }
-  };
+  }, [timeRanges, setTimeRanges]);
 
   return (
     <Section>

--- a/frontend/src/features/alerts/components/editor/useAlertEditorState.ts
+++ b/frontend/src/features/alerts/components/editor/useAlertEditorState.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import { type Alert, DEFAULT_STUDIO_ID, type TimeRange } from "shared";
+import { getStoredStudioId } from "../../../class-list/operators/studioStorage";
+import { selectStudioId } from "../../../class-list/selectors/selectStudioId";
+import { setStudioId } from "../../../class-list/slices/studioSlice";
+import type { BookableStatus } from "../../../filters/types/BookableStatus";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks/useStore";
+import { DAY_NAMES } from "../../constants/days";
+import { DEFAULT_TIME_RANGE } from "../../constants/timeRanges";
+
+export interface AlertEditorState {
+  selectedStudioId: string;
+  name: string;
+  setName: (name: string) => void;
+  selectedInstructors: Optional<string[]>;
+  setSelectedInstructors: (ids: Optional<string[]>) => void;
+  selectedDisciplines: Optional<string[]>;
+  setSelectedDisciplines: (ids: Optional<string[]>) => void;
+  timeRanges: Optional<TimeRange>[];
+  setTimeRanges: (ranges: Optional<TimeRange>[]) => void;
+  maxStatus: BookableStatus;
+  setMaxStatus: (status: BookableStatus) => void;
+}
+
+export const useAlertEditorState = (
+  alertToEdit: Partial<Alert>
+): AlertEditorState => {
+  const dispatch = useAppDispatch();
+  const selectedStudioId = useAppSelector(selectStudioId);
+
+  useEffect(() => {
+    if (alertToEdit.studioId) {
+      dispatch(setStudioId(alertToEdit.studioId));
+    } else {
+      dispatch(setStudioId(getStoredStudioId(DEFAULT_STUDIO_ID)));
+    }
+  }, [alertToEdit.studioId, dispatch]);
+
+  const [name, setName] = useState(alertToEdit.name || "");
+  const [selectedInstructors, setSelectedInstructors] = useState<
+    Optional<string[]>
+  >(alertToEdit.instructors || null);
+  const [selectedDisciplines, setSelectedDisciplines] = useState<
+    Optional<string[]>
+  >(alertToEdit.disciplines || null);
+  const [timeRanges, setTimeRanges] = useState<Optional<TimeRange>[]>(
+    () => alertToEdit.timeRanges || DAY_NAMES.map(() => DEFAULT_TIME_RANGE)
+  );
+  const [maxStatus, setMaxStatus] = useState<BookableStatus>(
+    alertToEdit.maxStatus || "free"
+  );
+
+  const lastStudioRef = useRef<string | undefined>(alertToEdit.studioId);
+  useEffect(() => {
+    if (
+      selectedStudioId &&
+      lastStudioRef.current &&
+      selectedStudioId !== lastStudioRef.current
+    ) {
+      setSelectedInstructors((cur) => (cur ? [] : cur));
+      setSelectedDisciplines((cur) => (cur ? [] : cur));
+    }
+    lastStudioRef.current = selectedStudioId;
+  }, [selectedStudioId]);
+
+  return {
+    selectedStudioId,
+    name,
+    setName,
+    selectedInstructors,
+    setSelectedInstructors,
+    selectedDisciplines,
+    setSelectedDisciplines,
+    timeRanges,
+    setTimeRanges,
+    maxStatus,
+    setMaxStatus,
+  };
+};

--- a/frontend/src/features/alerts/components/list/AlertsList.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsList.tsx
@@ -24,8 +24,8 @@ export const AlertsList = ({ alerts, onDuplicate, onEdit }: Props) => {
         <AlertsListItem
           key={alert.id}
           alert={alert}
-          onDuplicate={() => onDuplicate(alert)}
-          onEdit={() => onEdit(alert)}
+          onDuplicate={onDuplicate}
+          onEdit={onEdit}
         />
       ))}
     </ListWrapper>

--- a/frontend/src/features/alerts/components/list/AlertsListItem.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsListItem.tsx
@@ -184,8 +184,8 @@ const formatStatus = (status: string) =>
 
 interface Props {
   alert: Alert;
-  onDuplicate: () => void;
-  onEdit: () => void;
+  onDuplicate: (alert: Alert) => void;
+  onEdit: (alert: Alert) => void;
 }
 
 export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
@@ -205,20 +205,30 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
     return formatter.format(alert.created);
   }, [alert.created]);
 
+  const instructorNameById = useMemo(
+    () => new Map(allInstructors?.map((i) => [i.id, i.name])),
+    [allInstructors]
+  );
+
+  const disciplineNameById = useMemo(
+    () => new Map(allDisciplines?.map((d) => [d.id, d.name])),
+    [allDisciplines]
+  );
+
   const alertTitle = useMemo(() => {
     if (alert.name) return alert.name;
 
     const instructorNames =
       isNotEmpty(alert.instructors) && allInstructors
         ? alert.instructors
-            .map((id) => allInstructors.find((i) => i.id === id)?.name)
+            .map((id) => instructorNameById.get(id))
             .filter((n): n is string => Boolean(n))
         : null;
 
     const disciplineNames =
       isNotEmpty(alert.disciplines) && allDisciplines
         ? alert.disciplines
-            .map((id) => allDisciplines.find((d) => d.id === id)?.name)
+            .map((id) => disciplineNameById.get(id))
             .filter((n): n is string => Boolean(n))
         : null;
 
@@ -229,6 +239,8 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
     alert.disciplines,
     allInstructors,
     allDisciplines,
+    instructorNameById,
+    disciplineNameById,
   ]);
 
   const studioLabel =
@@ -276,12 +288,12 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
           >
             Test
           </ActionButton>
-          <ActionButton type="button" onClick={onEdit} aria-label="Edit alert">
+          <ActionButton type="button" onClick={() => onEdit(alert)} aria-label="Edit alert">
             Edit
           </ActionButton>
           <ActionButton
             type="button"
-            onClick={onDuplicate}
+            onClick={() => onDuplicate(alert)}
             aria-label="Duplicate alert"
           >
             Duplicate

--- a/frontend/src/features/class-list/hooks/useSwipeToRefresh.ts
+++ b/frontend/src/features/class-list/hooks/useSwipeToRefresh.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useLayoutEffect } from "react";
 
 // Raw drag distance required to trigger a refresh
 const REFRESH_THRESHOLD = 150;
@@ -18,6 +18,10 @@ const getScrollTop = () =>
 export const useSwipeToRefresh = ({ refresh }: Options) => {
   const swipeRef = useRef<HTMLDivElement>(null);
   const spinnerRef = useRef<HTMLDivElement>(null);
+  const refreshRef = useRef(refresh);
+  useLayoutEffect(() => {
+    refreshRef.current = refresh;
+  });
 
   const requiresSwipeToRefresh = useMemo(() => {
     return (
@@ -114,7 +118,7 @@ export const useSwipeToRefresh = ({ refresh }: Options) => {
         };
         // Guard against refresh() never settling (e.g. network hang)
         const timeoutId = setTimeout(hideSpinner, 10_000);
-        refresh().finally(() => {
+        refreshRef.current().finally(() => {
           clearTimeout(timeoutId);
           hideSpinner();
         });
@@ -141,7 +145,7 @@ export const useSwipeToRefresh = ({ refresh }: Options) => {
       document.removeEventListener("touchend", touchEnd);
       document.removeEventListener("touchcancel", touchCancel);
     };
-  }, [refresh, requiresSwipeToRefresh]);
+  }, [requiresSwipeToRefresh]);
 
   return { swipeRef, spinnerRef };
 };


### PR DESCRIPTION
- AlertsList/AlertsListItem: change onEdit/onDuplicate to (alert) => void so
  AlertsList can pass stable references directly instead of per-render wrappers,
  letting React.memo on AlertsListItem actually prevent re-renders

- useSwipeToRefresh: hold refresh in a ref (useLayoutEffect) and drop it from
  the effect dependency array so touch event listeners are only bound once
  instead of re-binding on every RTK Query refetch identity change

- AlertsListItem: replace O(n*m) .find()-in-map lookups with Map<id,name>
  built once per instructor/discipline list update

- StepFilters: wrap toggleInstructor/toggleDiscipline in useCallback; wrap
  InstructorsList and DisciplinesList sub-components in memo; pass query.refetch
  directly instead of () => query.refetch() in error states

- StepSchedule: wrap selectAll, clearAll, copyFirstToAll in useCallback so they
  are stable across renders

- AlertEditor: extract all form state + studio-change side-effects into a new
  useAlertEditorState hook, separating state management from rendering/navigation

- RegisteredDevicesEditor: change DeviceItem.onDelete to (token) => void, wrap
  DeviceItem in memo, wrap the parent onDelete handler in useCallback, and pass
  it directly to avoid per-render arrow wrappers in the devices map

https://claude.ai/code/session_01RjJXLbBuY13GyyJThcQyBu