### PR TITLE
[feat] Cache alerts page data in Redux to eliminate loading flash on re-visit

### DIFF
--- a/frontend/src/features/alerts/providers/AlertPreferencesProvider.tsx
+++ b/frontend/src/features/alerts/providers/AlertPreferencesProvider.tsx
@@ -1,10 +1,16 @@
 import { onValue, ref } from "firebase/database";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect } from "react";
 import type { AlertPreferences } from "shared";
 import { PATHS } from "shared";
 import { database } from "../../firebase/constants/database";
-import type { AsyncData } from "../../store/types/AsyncData";
+import { useAppDispatch, useAppSelector } from "../../store/hooks/useStore";
+import { store } from "../../store/constants/store";
 import { AlertPreferencesContext } from "../context/AlertPreferencesContext";
+import {
+  setAlertPreferencesData,
+  setAlertPreferencesFailed,
+  setAlertPreferencesLoading,
+} from "../slices/alertPreferencesSlice";
 
 interface Props {
   children: ReactNode;
@@ -12,37 +18,50 @@ interface Props {
 }
 
 export const AlertPreferencesProvider = ({ children, userId }: Props) => {
-  const [alertsState, setAlertsState] = useState<
-    AsyncData<Partial<AlertPreferences>>
-  >({
-    state: "idle",
-  });
+  const dispatch = useAppDispatch();
+  const preferencesCache = useAppSelector((state) => state.alertPreferences);
+
   useEffect(() => {
-    setAlertsState({ state: "loading" });
     const db = database;
     if (!db) {
-      setAlertsState({
-        state: "failed",
-        error: new Error("No database set up"),
-      });
+      dispatch(
+        setAlertPreferencesFailed({
+          userId,
+          error: { message: "No database set up" },
+        })
+      );
       return () => {};
     }
+
+    // Skip loading state if we already have data for this user
+    const cached = store.getState().alertPreferences;
+    if (cached.userId !== userId || cached.data.state !== "fulfilled") {
+      dispatch(setAlertPreferencesLoading(userId));
+    }
+
     const dbRef = ref(db, PATHS.alertPreferences(userId));
     const unsubscribe = onValue(
       dbRef,
       (snapshot) => {
         const values: Partial<AlertPreferences> | null = snapshot.val();
-        setAlertsState({ state: "fulfilled", data: values || {} });
+        dispatch(setAlertPreferencesData({ userId, data: values || {} }));
       },
       (error) => {
-        setAlertsState({ state: "failed", error });
+        dispatch(
+          setAlertPreferencesFailed({ userId, error: { message: error.message } })
+        );
       }
     );
     return () => unsubscribe();
-  }, [userId]);
+  }, [userId, dispatch]);
+
+  const contextValue =
+    preferencesCache.userId === userId
+      ? preferencesCache.data
+      : { state: "loading" as const };
 
   return (
-    <AlertPreferencesContext.Provider value={alertsState}>
+    <AlertPreferencesContext.Provider value={contextValue}>
       {children}
     </AlertPreferencesContext.Provider>
   );

--- a/frontend/src/features/alerts/providers/AlertsProvider.tsx
+++ b/frontend/src/features/alerts/providers/AlertsProvider.tsx
@@ -1,11 +1,17 @@
 import { onValue, ref } from "firebase/database";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect } from "react";
 import type { Alert } from "shared";
 import { PATHS } from "shared";
 import { database } from "../../firebase/constants/database";
-import type { AsyncData } from "../../store/types/AsyncData";
+import { useAppDispatch, useAppSelector } from "../../store/hooks/useStore";
+import { store } from "../../store/constants/store";
 import { DAY_NAMES } from "../constants/days";
 import { AlertsContext } from "../context/AlertsContext";
+import {
+  setAlertsData,
+  setAlertsFailed,
+  setAlertsLoading,
+} from "../slices/alertsSlice";
 
 interface Props {
   children: ReactNode;
@@ -13,19 +19,24 @@ interface Props {
 }
 
 export const AlertsProvider = ({ children, userId }: Props) => {
-  const [alertsState, setAlertsState] = useState<AsyncData<Alert[]>>({
-    state: "idle",
-  });
+  const dispatch = useAppDispatch();
+  const alertsCache = useAppSelector((state) => state.alerts);
+
   useEffect(() => {
-    setAlertsState({ state: "loading" });
     const db = database;
     if (!db) {
-      setAlertsState({
-        state: "failed",
-        error: new Error("No database set up"),
-      });
+      dispatch(
+        setAlertsFailed({ userId, error: { message: "No database set up" } })
+      );
       return () => {};
     }
+
+    // Skip loading state if we already have data for this user
+    const cached = store.getState().alerts;
+    if (cached.userId !== userId || cached.data.state !== "fulfilled") {
+      dispatch(setAlertsLoading(userId));
+    }
+
     const dbRef = ref(db, PATHS.alerts(userId));
     const unsubscribe = onValue(
       dbRef,
@@ -33,7 +44,7 @@ export const AlertsProvider = ({ children, userId }: Props) => {
         const values: { [key: string]: Omit<Alert, "id"> } | null =
           snapshot.val();
         if (!values) {
-          setAlertsState({ state: "fulfilled", data: [] });
+          dispatch(setAlertsData({ userId, data: [] }));
           return;
         }
         const alerts: Alert[] = Object.entries(values).map(([key, value]) => ({
@@ -43,17 +54,24 @@ export const AlertsProvider = ({ children, userId }: Props) => {
             .map((_, index) => value.timeRanges[index] || null),
           id: key,
         }));
-        setAlertsState({ state: "fulfilled", data: alerts });
+        dispatch(setAlertsData({ userId, data: alerts }));
       },
       (error) => {
-        setAlertsState({ state: "failed", error });
+        dispatch(
+          setAlertsFailed({ userId, error: { message: error.message } })
+        );
       }
     );
     return () => unsubscribe();
-  }, [userId]);
+  }, [userId, dispatch]);
+
+  const contextValue =
+    alertsCache.userId === userId
+      ? alertsCache.data
+      : { state: "loading" as const };
 
   return (
-    <AlertsContext.Provider value={alertsState}>
+    <AlertsContext.Provider value={contextValue}>
       {children}
     </AlertsContext.Provider>
   );

--- a/frontend/src/features/alerts/slices/alertPreferencesSlice.ts
+++ b/frontend/src/features/alerts/slices/alertPreferencesSlice.ts
@@ -1,0 +1,52 @@
+import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
+import type { AlertPreferences } from "shared";
+import type { AsyncData } from "../../store/types/AsyncData";
+
+interface AlertPreferencesCacheState {
+  userId: string | null;
+  data: AsyncData<Partial<AlertPreferences>>;
+}
+
+const initialState: AlertPreferencesCacheState = {
+  userId: null,
+  data: { state: "idle" },
+};
+
+const alertPreferencesSlice = createSlice({
+  name: "alertPreferences",
+  initialState,
+  reducers: {
+    setAlertPreferencesLoading(
+      _state: AlertPreferencesCacheState,
+      action: PayloadAction<string>
+    ): AlertPreferencesCacheState {
+      return { userId: action.payload, data: { state: "loading" } };
+    },
+    setAlertPreferencesData(
+      _state: AlertPreferencesCacheState,
+      action: PayloadAction<{ userId: string; data: Partial<AlertPreferences> }>
+    ): AlertPreferencesCacheState {
+      return {
+        userId: action.payload.userId,
+        data: { state: "fulfilled", data: action.payload.data },
+      };
+    },
+    setAlertPreferencesFailed(
+      _state: AlertPreferencesCacheState,
+      action: PayloadAction<{ userId: string; error: { message: string } }>
+    ): AlertPreferencesCacheState {
+      return {
+        userId: action.payload.userId,
+        data: { state: "failed", error: action.payload.error },
+      };
+    },
+  },
+});
+
+export const {
+  setAlertPreferencesLoading,
+  setAlertPreferencesData,
+  setAlertPreferencesFailed,
+} = alertPreferencesSlice.actions;
+
+export default alertPreferencesSlice.reducer;

--- a/frontend/src/features/alerts/slices/alertsSlice.ts
+++ b/frontend/src/features/alerts/slices/alertsSlice.ts
@@ -1,31 +1,49 @@
 import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
 import type { Alert } from "shared";
+import type { AsyncData } from "../../store/types/AsyncData";
 
-interface AlertState {
-  alerts: Alert[];
+interface AlertsCacheState {
+  userId: string | null;
+  data: AsyncData<Alert[]>;
 }
 
-const initialState: AlertState = {
-  alerts: [],
+const initialState: AlertsCacheState = {
+  userId: null,
+  data: { state: "idle" },
 };
 
 const alertsSlice = createSlice({
   name: "alerts",
   initialState,
-  // The `reducers` field lets us define reducers and generate associated actions
   reducers: {
-    addAlert(state, action: PayloadAction<Alert>) {
-      state.alerts.push(action.payload);
+    setAlertsLoading(
+      _state: AlertsCacheState,
+      action: PayloadAction<string>
+    ): AlertsCacheState {
+      return { userId: action.payload, data: { state: "loading" } };
     },
-    setAlerts(state, action: PayloadAction<Alert[]>) {
-      state.alerts = action.payload;
+    setAlertsData(
+      _state: AlertsCacheState,
+      action: PayloadAction<{ userId: string; data: Alert[] }>
+    ): AlertsCacheState {
+      return {
+        userId: action.payload.userId,
+        data: { state: "fulfilled", data: action.payload.data },
+      };
     },
-    removeAlerts(state) {
-      state.alerts = [];
+    setAlertsFailed(
+      _state: AlertsCacheState,
+      action: PayloadAction<{ userId: string; error: { message: string } }>
+    ): AlertsCacheState {
+      return {
+        userId: action.payload.userId,
+        data: { state: "failed", error: action.payload.error },
+      };
     },
   },
 });
 
-export const { addAlert, setAlerts, removeAlerts } = alertsSlice.actions;
+export const { setAlertsLoading, setAlertsData, setAlertsFailed } =
+  alertsSlice.actions;
 
 export default alertsSlice.reducer;

--- a/frontend/src/features/messaging/providers/RegisteredDevicesProvider.tsx
+++ b/frontend/src/features/messaging/providers/RegisteredDevicesProvider.tsx
@@ -1,8 +1,14 @@
 import { onValue, ref } from "firebase/database";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect } from "react";
 import { database } from "../../firebase/constants/database";
-import type { AsyncData } from "../../store/types/AsyncData";
+import { useAppDispatch, useAppSelector } from "../../store/hooks/useStore";
+import { store } from "../../store/constants/store";
 import { RegisteredDevicesContext } from "../context/RegisteredDevicesContext";
+import {
+  setRegisteredDevicesData,
+  setRegisteredDevicesFailed,
+  setRegisteredDevicesLoading,
+} from "../slices/registeredDevicesSlice";
 import type { RegisteredDevice } from "../types/RegisteredDevice";
 
 interface Props {
@@ -11,38 +17,51 @@ interface Props {
 }
 
 export const RegisteredDevicesProvider = ({ children, userId }: Props) => {
-  const [state, setState] = useState<
-    AsyncData<{ [key: string]: RegisteredDevice }>
-  >({
-    state: "idle",
-  });
+  const dispatch = useAppDispatch();
+  const devicesCache = useAppSelector((state) => state.registeredDevices);
+
   useEffect(() => {
-    setState({ state: "loading" });
     const db = database;
     if (!db) {
-      setState({
-        state: "failed",
-        error: new Error("No database set up"),
-      });
+      dispatch(
+        setRegisteredDevicesFailed({
+          userId,
+          error: { message: "No database set up" },
+        })
+      );
       return () => {};
     }
+
+    // Skip loading state if we already have data for this user
+    const cached = store.getState().registeredDevices;
+    if (cached.userId !== userId || cached.data.state !== "fulfilled") {
+      dispatch(setRegisteredDevicesLoading(userId));
+    }
+
     const dbRef = ref(db, `messagingTokens/${userId}`);
     const unsubscribe = onValue(
       dbRef,
       (snapshot) => {
         const values: { [key: string]: RegisteredDevice } | null =
           snapshot.val();
-        setState({ state: "fulfilled", data: values || {} });
+        dispatch(setRegisteredDevicesData({ userId, data: values || {} }));
       },
       (error) => {
-        setState({ state: "failed", error });
+        dispatch(
+          setRegisteredDevicesFailed({ userId, error: { message: error.message } })
+        );
       }
     );
     return () => unsubscribe();
-  }, [userId]);
+  }, [userId, dispatch]);
+
+  const contextValue =
+    devicesCache.userId === userId
+      ? devicesCache.data
+      : { state: "loading" as const };
 
   return (
-    <RegisteredDevicesContext.Provider value={state}>
+    <RegisteredDevicesContext.Provider value={contextValue}>
       {children}
     </RegisteredDevicesContext.Provider>
   );

--- a/frontend/src/features/messaging/slices/registeredDevicesSlice.ts
+++ b/frontend/src/features/messaging/slices/registeredDevicesSlice.ts
@@ -1,0 +1,54 @@
+import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
+import type { AsyncData } from "../../store/types/AsyncData";
+import type { RegisteredDevice } from "../types/RegisteredDevice";
+
+type DevicesMap = { [key: string]: RegisteredDevice };
+
+interface RegisteredDevicesCacheState {
+  userId: string | null;
+  data: AsyncData<DevicesMap>;
+}
+
+const initialState: RegisteredDevicesCacheState = {
+  userId: null,
+  data: { state: "idle" },
+};
+
+const registeredDevicesSlice = createSlice({
+  name: "registeredDevices",
+  initialState,
+  reducers: {
+    setRegisteredDevicesLoading(
+      _state: RegisteredDevicesCacheState,
+      action: PayloadAction<string>
+    ): RegisteredDevicesCacheState {
+      return { userId: action.payload, data: { state: "loading" } };
+    },
+    setRegisteredDevicesData(
+      _state: RegisteredDevicesCacheState,
+      action: PayloadAction<{ userId: string; data: DevicesMap }>
+    ): RegisteredDevicesCacheState {
+      return {
+        userId: action.payload.userId,
+        data: { state: "fulfilled", data: action.payload.data },
+      };
+    },
+    setRegisteredDevicesFailed(
+      _state: RegisteredDevicesCacheState,
+      action: PayloadAction<{ userId: string; error: { message: string } }>
+    ): RegisteredDevicesCacheState {
+      return {
+        userId: action.payload.userId,
+        data: { state: "failed", error: action.payload.error },
+      };
+    },
+  },
+});
+
+export const {
+  setRegisteredDevicesLoading,
+  setRegisteredDevicesData,
+  setRegisteredDevicesFailed,
+} = registeredDevicesSlice.actions;
+
+export default registeredDevicesSlice.reducer;

--- a/frontend/src/features/store/constants/store.ts
+++ b/frontend/src/features/store/constants/store.ts
@@ -4,15 +4,19 @@ import {
   configureStore,
 } from "@reduxjs/toolkit";
 import alertsReducer from "../../alerts/slices/alertsSlice";
+import alertPreferencesReducer from "../../alerts/slices/alertPreferencesSlice";
 import { pelotonApi } from "../../class-list/services/pelotonApi";
 import { studioSlice } from "../../class-list/slices/studioSlice";
 import filtersReducer from "../../filters/slices/filtersSlice";
+import registeredDevicesReducer from "../../messaging/slices/registeredDevicesSlice";
 import sessionReducer from "../../session/slices/sessionSlice";
 
 export const store = configureStore({
   reducer: {
     alerts: alertsReducer,
+    alertPreferences: alertPreferencesReducer,
     filters: filtersReducer,
+    registeredDevices: registeredDevicesReducer,
     session: sessionReducer,
     [pelotonApi.reducerPath]: pelotonApi.reducer,
     [studioSlice.name]: studioSlice.reducer,


### PR DESCRIPTION
Alerts, preferences, and registered devices were fetched fresh from Firebase
on every visit to /alerts, causing a loading spinner on every navigation. The
three providers now cache their data in Redux slices keyed by userId. On
subsequent visits the cached data is provided to context immediately, with the
Firebase listener still running in the background to keep it fresh.

https://claude.ai/code/session_01UdLgNg2fDojv9FZEjQDezM