### PR TITLE
[feat] Add waitlist position alerts with dedicated landing page

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.19
+
+- Added waitlist position alerts. Alerts with `waitlistAlerts` enabled now fire a `waitlist_changed` notification each time `waiting_count` changes for a matching class. Instructor, discipline, and schedule filters apply; the bookable-status threshold is ignored so the check works even when the class is full. Each distinct count value gets its own debounce key so every shift fires independently. The notification links to a dedicated in-app page (`/waitlist-alert`) rather than the class listing, prompting the user to check their email for the 2-hour acceptance window
+
 ## 0.0.18
 
 - Push notifications now link directly to the Peloton class booking page instead of the app root. Added a `frontend_url` add-on option (set it to your hosted app URL, e.g. `https://abbondanzo.github.io/peloton-reservations`) so the notification click lands on the correct subpath and immediately redirects to the class

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,5 +1,5 @@
 name: Peloton Reservations
-version: "0.0.18"
+version: "0.0.19"
 image: ghcr.io/abbondanzo/peloton-reservations
 slug: peloton_reservations
 description: Polls Peloton studio schedules and sends class availability alerts

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Backend comparison service for sending notifications",
   "scripts": {
     "build": "tsc",

--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -13,6 +13,7 @@ import {
   buildSnapshot,
   getBookableStatus,
   getChangeType,
+  getWaitlistChangeType,
   matchesAlert,
 } from "shared";
 import { logger } from "./logger";
@@ -28,6 +29,16 @@ function buildNotificationLink(classUrl: string | null | undefined): string {
   const base = FRONTEND_URL || "/";
   if (!classUrl) return base;
   return `${FRONTEND_URL}/?classUrl=${encodeURIComponent(classUrl)}`;
+}
+
+function buildWaitlistAlertLink(classData: RawClass, studioId: string): string {
+  const params = new URLSearchParams({
+    classId: String(classData.id),
+    studioId,
+    startsAt: classData.starts_at,
+    waitingCount: String(classData.waiting_count),
+  });
+  return `${FRONTEND_URL}/#/waitlist-alert?${params}`;
 }
 
 /** How often to flush the pending-notification queue. */
@@ -139,6 +150,20 @@ export class Alerter implements DiffDelegate {
           if (changeType) {
             this.enqueueNotification(userId, studioId, entry.new, changeType);
           }
+          const waitlistChangeType = getWaitlistChangeType(
+            alert,
+            entry.old,
+            entry.new
+          );
+          if (waitlistChangeType) {
+            this.enqueueNotification(
+              userId,
+              studioId,
+              entry.new,
+              waitlistChangeType,
+              String(entry.new.waiting_count)
+            );
+          }
         }
       }
     }
@@ -152,9 +177,12 @@ export class Alerter implements DiffDelegate {
     userId: string,
     studioId: string,
     classData: RawClass,
-    changeType: ChangeType
+    changeType: ChangeType,
+    extraKey?: string
   ) {
-    const debounceKey = `${userId}:${classData.id}:${changeType}`;
+    const debounceKey = extraKey
+      ? `${userId}:${classData.id}:${changeType}:${extraKey}`
+      : `${userId}:${classData.id}:${changeType}`;
     const now = Date.now();
     const delayMin = this.alertPreferences[userId]?.notificationDelayMin ?? 0;
     const delayMs = delayMin * 60 * 1000;
@@ -237,6 +265,11 @@ export class Alerter implements DiffDelegate {
 
     const { title, body } = this.buildNotificationContent(pending);
 
+    const isWaitlistChanged = pending.changeType === "waitlist_changed";
+    const notificationLink = isWaitlistChanged
+      ? buildWaitlistAlertLink(pending.classData, pending.studioId)
+      : buildNotificationLink(pending.classData.customer_url);
+
     const message: admin.messaging.MulticastMessage = {
       tokens,
       notification: { title, body },
@@ -247,6 +280,7 @@ export class Alerter implements DiffDelegate {
         changeType: pending.changeType,
         classUrl: pending.classData.customer_url ?? "",
         startsAt: pending.classData.starts_at,
+        waitingCount: String(pending.classData.waiting_count),
       },
       webpush: {
         notification: {
@@ -257,7 +291,7 @@ export class Alerter implements DiffDelegate {
           requireInteraction: true,
         },
         fcmOptions: {
-          link: buildNotificationLink(pending.classData.customer_url),
+          link: notificationLink,
         },
       },
     };
@@ -322,6 +356,13 @@ export class Alerter implements DiffDelegate {
           title: "Waitlist available!",
           body: `${instructorName} — ${className}${timeStr} waitlist is open`,
         };
+      case "waitlist_changed": {
+        const count = classData.waiting_count;
+        return {
+          title: "Waitlist count changed",
+          body: `${count} ${count === 1 ? "person" : "people"} on the waitlist — ${instructorName} — ${className}${timeStr}`,
+        };
+      }
     }
   }
 

--- a/frontend/src/features/alerts/components/editor/AlertEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/AlertEditor.tsx
@@ -142,6 +142,8 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
     setTimeRanges,
     maxStatus,
     setMaxStatus,
+    waitlistAlerts,
+    setWaitlistAlerts,
   } = useAlertEditorState(alertToEdit);
 
   const canGoNext = currentStep < STEPS.length - 1;
@@ -171,6 +173,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
       disciplines: selectedDisciplines,
       timeRanges,
       maxStatus,
+      ...(waitlistAlerts ? { waitlistAlerts: true } : {}),
     };
 
     try {
@@ -195,6 +198,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
     selectedDisciplines,
     timeRanges,
     maxStatus,
+    waitlistAlerts,
     onSave,
   ]);
 
@@ -225,6 +229,8 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
             onStudioChange={(id) => dispatch(setStudioId(id))}
             maxStatus={maxStatus}
             onStatusChange={setMaxStatus}
+            waitlistAlerts={waitlistAlerts}
+            onWaitlistAlertsChange={setWaitlistAlerts}
           />
         )}
         {currentStep === 1 && (
@@ -247,6 +253,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
             selectedInstructors={selectedInstructors}
             selectedDisciplines={selectedDisciplines}
             timeRanges={timeRanges}
+            waitlistAlerts={waitlistAlerts}
           />
         )}
       </StepContent>

--- a/frontend/src/features/alerts/components/editor/StepBasics.tsx
+++ b/frontend/src/features/alerts/components/editor/StepBasics.tsx
@@ -1,7 +1,9 @@
+import { useId } from "react";
 import { STUDIOS } from "shared";
 import styled from "styled-components";
 import type { BookableStatus } from "../../../filters/types/BookableStatus";
 import { mediaMobile } from "../../../theme/constants/queries";
+import { border, hover } from "../../../theme/constants/styles";
 import { TextInput } from "../../../theme/components/TextInput";
 import { OptionCard } from "./OptionCard";
 
@@ -36,6 +38,47 @@ const SectionSpacer = styled.div`
   ${mediaMobile`
     margin-top: 24px;
   `}
+`;
+
+const CheckCard = styled.label`
+  ${border}
+  ${hover}
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s;
+
+  &:has(input:checked) {
+    border-color: ${(props) => props.theme.colors.accent};
+    background-color: ${(props) => props.theme.colors.accent}0a;
+  }
+`;
+
+const CheckCardTextBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+`;
+
+const CheckCardLabel = styled.span`
+  font-weight: 500;
+  color: ${(props) => props.theme.colors.main};
+`;
+
+const CheckCardHint = styled.span`
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.secondary};
+`;
+
+const CheckCardInput = styled.input`
+  accent-color: ${(props) => props.theme.colors.accent};
+  flex-shrink: 0;
 `;
 
 interface StudioOption {
@@ -74,6 +117,8 @@ interface Props {
   onStudioChange: (studioId: string) => void;
   maxStatus: BookableStatus;
   onStatusChange: (status: BookableStatus) => void;
+  waitlistAlerts: boolean;
+  onWaitlistAlertsChange: (enabled: boolean) => void;
 }
 
 export const StepBasics = ({
@@ -83,7 +128,10 @@ export const StepBasics = ({
   onStudioChange,
   maxStatus,
   onStatusChange,
+  waitlistAlerts,
+  onWaitlistAlertsChange,
 }: Props) => {
+  const waitlistCheckId = useId();
   return (
     <div>
       <TextInput
@@ -131,6 +179,30 @@ export const StepBasics = ({
             />
           ))}
         </OptionsStack>
+      </Section>
+
+      <SectionSpacer />
+
+      <Section>
+        <Legend>Waitlist position alerts</Legend>
+        <Description>
+          Get a notification whenever the waitlist count changes — useful for
+          monitoring if it&apos;s your turn to accept a spot.
+        </Description>
+        <CheckCard htmlFor={waitlistCheckId}>
+          <CheckCardInput
+            type="checkbox"
+            id={waitlistCheckId}
+            checked={waitlistAlerts}
+            onChange={(e) => onWaitlistAlertsChange(e.target.checked)}
+          />
+          <CheckCardTextBlock>
+            <CheckCardLabel>Notify me when the waitlist count changes</CheckCardLabel>
+            <CheckCardHint>
+              Opens a prompt to check your email when the count shifts
+            </CheckCardHint>
+          </CheckCardTextBlock>
+        </CheckCard>
       </Section>
     </div>
   );

--- a/frontend/src/features/alerts/components/editor/StepReview.tsx
+++ b/frontend/src/features/alerts/components/editor/StepReview.tsx
@@ -112,6 +112,7 @@ interface Props {
   selectedInstructors: Optional<string[]>;
   selectedDisciplines: Optional<string[]>;
   timeRanges: Optional<TimeRange>[];
+  waitlistAlerts: boolean;
 }
 
 export const StepReview = ({
@@ -121,6 +122,7 @@ export const StepReview = ({
   selectedInstructors,
   selectedDisciplines,
   timeRanges,
+  waitlistAlerts,
 }: Props) => {
   const studio = STUDIOS[studioId];
   const enabledDays = DAY_NAMES.filter((_, i) => timeRanges[i]);
@@ -207,6 +209,11 @@ export const StepReview = ({
             </RowValue>
           </SummaryRow>
         )}
+
+        <SummaryRow>
+          <RowLabel>Waitlist alerts</RowLabel>
+          <RowValue>{waitlistAlerts ? "On" : "Off"}</RowValue>
+        </SummaryRow>
       </SummaryCard>
     </Section>
   );

--- a/frontend/src/features/alerts/components/editor/useAlertEditorState.ts
+++ b/frontend/src/features/alerts/components/editor/useAlertEditorState.ts
@@ -20,6 +20,8 @@ export interface AlertEditorState {
   setTimeRanges: (ranges: Optional<TimeRange>[]) => void;
   maxStatus: BookableStatus;
   setMaxStatus: (status: BookableStatus) => void;
+  waitlistAlerts: boolean;
+  setWaitlistAlerts: (enabled: boolean) => void;
 }
 
 export const useAlertEditorState = (
@@ -49,6 +51,9 @@ export const useAlertEditorState = (
   const [maxStatus, setMaxStatus] = useState<BookableStatus>(
     alertToEdit.maxStatus || "free"
   );
+  const [waitlistAlerts, setWaitlistAlerts] = useState<boolean>(
+    alertToEdit.waitlistAlerts ?? false
+  );
 
   const lastStudioRef = useRef<string | undefined>(alertToEdit.studioId);
   useEffect(() => {
@@ -75,5 +80,7 @@ export const useAlertEditorState = (
     setTimeRanges,
     maxStatus,
     setMaxStatus,
+    waitlistAlerts,
+    setWaitlistAlerts,
   };
 };

--- a/frontend/src/features/navigation/constants/paths.ts
+++ b/frontend/src/features/navigation/constants/paths.ts
@@ -6,6 +6,7 @@ export const Paths = {
   ALERTS_EDITOR: "/alerts/edit",
   ALERTS_SIMULATION: "/alerts/:alertId/test",
   STATS: "/stats",
+  WAITLIST_ALERT: "/waitlist-alert",
 } as const;
 
 export const alertsSimulationPath = (alertId: string) =>

--- a/frontend/src/features/navigation/constants/router.tsx
+++ b/frontend/src/features/navigation/constants/router.tsx
@@ -13,6 +13,7 @@ import { ClassListRoot } from "../../class-list/components/ClassListRoot";
 import { AdminRoute } from "../../session/components/AdminRoute";
 import { SignInRoot } from "../../session/components/SignInRoot";
 import { StatsRoot } from "../../stats/components/StatsRoot";
+import { WaitlistAlertRoot } from "../../waitlist/components/WaitlistAlertRoot";
 import { Paths } from "./paths";
 
 export const router = createHashRouter(
@@ -24,6 +25,7 @@ export const router = createHashRouter(
         <Route path="edit" element={<AlertsEditorRoot />} />
         <Route path=":alertId/test" element={<AlertSimulationRoot />} />
       </Route>
+      <Route path={Paths.WAITLIST_ALERT} element={<WaitlistAlertRoot />} />
       <Route path={Paths.SIGN_IN} element={<SignInRoot />} />
       <Route path={Paths.ABOUT} element={<AboutRoot />} />
       <Route

--- a/frontend/src/features/waitlist/components/WaitlistAlertRoot.tsx
+++ b/frontend/src/features/waitlist/components/WaitlistAlertRoot.tsx
@@ -1,0 +1,154 @@
+import { useSearchParams } from "react-router-dom";
+import { STUDIOS } from "shared";
+import styled from "styled-components";
+import { NavbarProvider } from "../../navigation/components/NavbarProvider";
+import { mediaMobile } from "../../theme/constants/queries";
+
+const PageWrapper = styled.div`
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+
+  ${mediaMobile`
+    padding: 24px 16px;
+  `}
+`;
+
+const Icon = styled.div`
+  font-size: 48px;
+  margin-bottom: 20px;
+`;
+
+const Title = styled.h1`
+  font-size: 22px;
+  font-weight: 700;
+  color: ${(p) => p.theme.colors.main};
+  margin: 0 0 12px;
+`;
+
+const Body = styled.p`
+  font-size: 15px;
+  line-height: 1.6;
+  color: ${(p) => p.theme.colors.secondary};
+  margin: 0 0 28px;
+`;
+
+const ClassCard = styled.div`
+  width: 100%;
+  background-color: ${(p) => p.theme.colors.mainSurface};
+  border: 1px solid ${(p) => p.theme.borderColor};
+  border-radius: ${(p) => p.theme.borderRadius};
+  padding: 14px 16px;
+  margin-bottom: 28px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const ClassLabel = styled.span`
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: ${(p) => p.theme.colors.secondary};
+`;
+
+const ClassValue = styled.span`
+  font-size: 15px;
+  color: ${(p) => p.theme.colors.main};
+`;
+
+const MailButton = styled.a`
+  display: inline-block;
+  padding: 12px 32px;
+  border-radius: ${(p) => p.theme.borderRadius};
+  background-color: ${(p) => p.theme.colors.accent};
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: filter 0.15s;
+
+  &:hover {
+    filter: brightness(92%);
+  }
+`;
+
+const Hint = styled.p`
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: ${(p) => p.theme.colors.secondary};
+`;
+
+function formatStartsAt(startsAt: string, studioId: string): string | null {
+  if (!startsAt) return null;
+  try {
+    const timezone = STUDIOS[studioId]?.timezone;
+    return new Date(startsAt).toLocaleString("en-US", {
+      timeZone: timezone ?? "UTC",
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "short",
+    });
+  } catch {
+    return null;
+  }
+}
+
+export const WaitlistAlertRoot = () => {
+  const [params] = useSearchParams();
+  const studioId = params.get("studioId") ?? "";
+  const startsAt = params.get("startsAt") ?? "";
+  const waitingCount = params.get("waitingCount");
+  const studio = STUDIOS[studioId];
+  const formattedTime = formatStartsAt(startsAt, studioId);
+  const count = waitingCount !== null ? parseInt(waitingCount, 10) : null;
+
+  return (
+    <NavbarProvider>
+      <PageWrapper>
+        <Icon>📬</Icon>
+        <Title>Waitlist count changed</Title>
+        <Body>
+          The number of people on the waitlist just changed
+          {count !== null
+            ? ` — there ${count === 1 ? "is now 1 person" : `are now ${count} people`} ahead`
+            : ""}
+          . If you joined this waitlist, check your email — Peloton sends a
+          message when it&apos;s your turn, and you&apos;ll have a 2-hour window
+          to accept.
+        </Body>
+
+        {(formattedTime || studio) && (
+          <ClassCard>
+            {studio && (
+              <>
+                <ClassLabel>Studio</ClassLabel>
+                <ClassValue>{studio.location}</ClassValue>
+              </>
+            )}
+            {formattedTime && (
+              <>
+                <ClassLabel style={{ marginTop: studio ? 8 : 0 }}>
+                  Class time
+                </ClassLabel>
+                <ClassValue>{formattedTime}</ClassValue>
+              </>
+            )}
+          </ClassCard>
+        )}
+
+        <MailButton href="mailto:">Open Mail App</MailButton>
+        <Hint>Opens your device&apos;s default mail app.</Hint>
+      </PageWrapper>
+    </NavbarProvider>
+  );
+};

--- a/frontend/src/messaging-sw.ts
+++ b/frontend/src/messaging-sw.ts
@@ -96,10 +96,21 @@ if (self.location.pathname.includes("/pr-preview/")) {
       event.notification.close();
       const swPathname = self.location.pathname;
       const basePath = swPathname.substring(0, swPathname.lastIndexOf("/") + 1);
-      const classUrl: string | undefined = event.notification.data?.classUrl;
-      const appUrl = classUrl
-        ? `${basePath}?classUrl=${encodeURIComponent(classUrl)}`
-        : basePath;
+      const data: Record<string, string> = event.notification.data ?? {};
+      let appUrl: string;
+      if (data.changeType === "waitlist_changed") {
+        const params = new URLSearchParams({
+          classId: data.classId ?? "",
+          studioId: data.studioId ?? "",
+          startsAt: data.startsAt ?? "",
+          waitingCount: data.waitingCount ?? "",
+        });
+        appUrl = `${basePath}#/waitlist-alert?${params}`;
+      } else {
+        appUrl = data.classUrl
+          ? `${basePath}?classUrl=${encodeURIComponent(data.classUrl)}`
+          : basePath;
+      }
       event.waitUntil(
         self.clients
           .matchAll({ type: "window", includeUncontrolled: true })

--- a/shared/src/alertMatching.ts
+++ b/shared/src/alertMatching.ts
@@ -3,7 +3,11 @@ import type { RawClass } from "./classApi";
 import { isFree, isWaitlistFull } from "./classStatus";
 import { STUDIOS } from "./studios";
 
-export type ChangeType = "added" | "became_free" | "waitlist_opened";
+export type ChangeType =
+  | "added"
+  | "became_free"
+  | "waitlist_opened"
+  | "waitlist_changed";
 
 export type NearMissReason = "instructor" | "time" | "discipline" | "status";
 
@@ -64,6 +68,19 @@ export const classifyMatch = (
   if (failures.length === 0) return { type: "match" };
   if (failures.length === 1) return { type: "near-miss", reason: failures[0] };
   return { type: "skipped" };
+};
+
+export const getWaitlistChangeType = (
+  alert: Alert,
+  oldClass: RawClass,
+  newClass: RawClass
+): "waitlist_changed" | null => {
+  if (!alert.waitlistAlerts) return null;
+  if (oldClass.waiting_count === newClass.waiting_count) return null;
+  if (!checkDiscipline(newClass, alert)) return null;
+  if (!checkInstructor(newClass, alert)) return null;
+  if (!checkTimeRange(newClass, alert)) return null;
+  return "waitlist_changed";
 };
 
 export const getChangeType = (

--- a/shared/src/alerts.ts
+++ b/shared/src/alerts.ts
@@ -27,6 +27,7 @@ export interface Alert {
   maxStatus: BookableStatus;
   timeRanges: Optional<TimeRange>[];
   studioId: string;
+  waitlistAlerts?: boolean;
 }
 
 export interface AlertPreferences {


### PR DESCRIPTION
When an alert has waitlistAlerts enabled, the backend fires a
waitlist_changed notification each time waiting_count changes for a
matching class (checking instructor/discipline/schedule filters but
not status). Each unique count value gets its own debounce key so
every shift fires independently.

Tapping the notification opens a new /waitlist-alert route instead
of the class listing. That page explains the 2-hour acceptance
window and provides an "Open Mail App" button (href="mailto:") that
works on iOS and Android. Class time and studio info are passed
through URL params so the page can show them without an API call.

The service worker and FCM link both point to the new route for
waitlist_changed notifications; all other change types continue to
route to the class listing as before.

The alert editor gains a "Waitlist position alerts" checkbox on
Step 1 (Basics), and the Review step surfaces its on/off state.

https://claude.ai/code/session_01JFfCK7izzqmzfSah3SCLRA