### PR TITLE
[fix] Fix discipline checkmarks not showing when IDs are stale or mistyped

### DIFF
--- a/frontend/src/features/alerts/components/editor/StepFilters.tsx
+++ b/frontend/src/features/alerts/components/editor/StepFilters.tsx
@@ -155,7 +155,9 @@ export const StepFilters = ({
     const valid = new Set(
       disciplinesQuery.currentData.map((d) => String(d.id))
     );
-    const filtered = initial.filter((id) => valid.has(String(id)));
+    const filtered = initial
+      .filter((id) => valid.has(String(id)))
+      .map(String);
     if (filtered.length < initial.length) {
       setSelectedDisciplines(filtered);
       initialDisciplines.current = filtered;

--- a/frontend/src/features/filters/components/DisciplinesGroup.tsx
+++ b/frontend/src/features/filters/components/DisciplinesGroup.tsx
@@ -1,10 +1,11 @@
+import { useEffect, useRef } from "react";
 import { DisciplineIcon } from "../../class-list/components/DisciplineIcon";
 import { selectStudioId } from "../../class-list/selectors/selectStudioId";
 import { useGetDisciplinesQuery } from "../../class-list/services/pelotonApi";
 import type { Discipline } from "../../class-list/types/Discipline";
 import { useAppDispatch, useAppSelector } from "../../store/hooks/useStore";
 import { useDisciplineFilters } from "../hooks/useDisciplineFilters";
-import { resetDisciplines } from "../slices/filtersSlice";
+import { resetDisciplines, setDisciplines } from "../slices/filtersSlice";
 import {
   FilterCheckBox,
   FilterItem,
@@ -41,6 +42,18 @@ const DisciplinesGroupContent = () => {
   const studioId = useAppSelector(selectStudioId);
   const { currentData, isLoading, error } = useGetDisciplinesQuery(studioId);
   const { selectedDisciplines, toggleDiscipline } = useDisciplineFilters();
+  const dispatch = useAppDispatch();
+  const initialDisciplines = useRef(selectedDisciplines);
+
+  useEffect(() => {
+    const initial = initialDisciplines.current;
+    if (!currentData || initial.length === 0) return;
+    const valid = new Set(currentData.map((d) => d.id));
+    const filtered = initial.filter((id) => valid.has(id));
+    if (filtered.length < initial.length) {
+      dispatch(setDisciplines(filtered));
+    }
+  }, [currentData, dispatch]);
 
   if (error && !isLoading) {
     return <FilterStateText>Failed to load disciplines</FilterStateText>;

--- a/frontend/src/features/filters/slices/filtersSlice.ts
+++ b/frontend/src/features/filters/slices/filtersSlice.ts
@@ -69,6 +69,10 @@ const filtersSlice = createSlice({
       }
       setStoredDisciplines(state.selectedDisciplines);
     },
+    setDisciplines(state, action: PayloadAction<string[]>) {
+      state.selectedDisciplines = action.payload;
+      setStoredDisciplines(state.selectedDisciplines);
+    },
     resetDisciplines(state) {
       state.selectedDisciplines = [];
       setStoredDisciplines(state.selectedDisciplines);
@@ -81,6 +85,7 @@ export const {
   toggleInstructor,
   resetInstructors,
   toggleDiscipline,
+  setDisciplines,
   resetDisciplines,
 } = filtersSlice.actions;
 


### PR DESCRIPTION
Two related causes:
- Old alerts in Firebase could store discipline IDs as numbers; the
  reconciliation in StepFilters validated them via String() coercion but
  left them as numbers, so selectedIds.includes(discipline.id) always
  failed (123 !== "123"). Fixed by mapping filtered IDs through String().
- The class list filter had no reconciliation at all, so stale discipline
  IDs from localStorage (e.g. after a Peloton API update changed an ID)
  would persist indefinitely. Added the same mount-time cleanup used in
  StepFilters, dispatching setDisciplines (new action) with only the
  IDs that still exist in the current API response.

https://claude.ai/code/session_01LBnwBWMxbMgNf2ajzNUv9u