### PR TITLE
[feat] Add watchlist step to alert editor for targeted waitlist alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,17 @@ Types are defined in `shared/src/alerts.ts` and `frontend/src/features/`. Look t
 - `useId()` in `TextInput`, `aria-describedby`, `aria-expanded`/`aria-haspopup` on popovers
 - `React.memo` on `ClassListItem`, `AlertsListItem`
 
+## Backend Versioning
+
+Every PR that contains a backend change (any file under `backend/` or `shared/`) **must** include a version bump and changelog entry as part of the same PR. Do this before committing/pushing the rest of the changes:
+
+1. Increment the patch version (`0.0.x → 0.0.x+1`) in **all three** of these files:
+   - `backend/package.json` — `"version"` field
+   - `backend/config.yaml` — `version:` field
+   - `backend/CHANGELOG.md` — prepend a new `## 0.0.x` section describing the change
+
+The changelog entry should be written in plain English, one bullet per logical change, describing *what* changed and *why* it matters (not a list of files touched).
+
 ## Git & PR Conventions
 Both commit messages and PR titles must use the same semantic prefix format: `[feat]`, `[fix]`, `[chore]`, `[refactor]`, `[docs]`, `[test]`, `[style]`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Every PR that contains a backend change (any file under `backend/` or `shared/`)
    - `backend/config.yaml` — `version:` field
    - `backend/CHANGELOG.md` — prepend a new `## 0.0.x` section describing the change
 
-The changelog entry should be written in plain English, one bullet per logical change, describing *what* changed and *why* it matters (not a list of files touched). Only include user-facing or behavioral changes — omit internal build fixes, type corrections, and refactors that don't affect runtime behavior.
+The changelog entry should be written in plain English, one bullet per logical change, describing *what changed behaviorally* for the user (not a list of files touched, type names, or method names). Only include user-facing or behavioral changes — omit internal build fixes, type corrections, and refactors that don't affect runtime behavior.
 
 ## Git & PR Conventions
 Both commit messages and PR titles must use the same semantic prefix format: `[feat]`, `[fix]`, `[chore]`, `[refactor]`, `[docs]`, `[test]`, `[style]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Every PR that contains a backend change (any file under `backend/` or `shared/`)
    - `backend/config.yaml` — `version:` field
    - `backend/CHANGELOG.md` — prepend a new `## 0.0.x` section describing the change
 
-The changelog entry should be written in plain English, one bullet per logical change, describing *what* changed and *why* it matters (not a list of files touched).
+The changelog entry should be written in plain English, one bullet per logical change, describing *what* changed and *why* it matters (not a list of files touched). Only include user-facing or behavioral changes — omit internal build fixes, type corrections, and refactors that don't affect runtime behavior.
 
 ## Git & PR Conventions
 Both commit messages and PR titles must use the same semantic prefix format: `[feat]`, `[fix]`, `[chore]`, `[refactor]`, `[docs]`, `[test]`, `[style]`

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.0.20
 
 - Added `watchedClassIds` field to the `Alert` type. When set, `getWaitlistChangeType` skips `waitlist_changed` notifications for any class whose ID is not in the list, letting users target only the specific classes they have joined the waitlist for
-- Fixed TypeScript build error (TS2550): replaced `Array.prototype.includes` with `indexOf` in `alertMatching.ts` — `includes` is not available under the `es6` lib target
 
 ## 0.0.19
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.20
 
-- Fixed TypeScript build error (TS2550) caused by `Array.prototype.includes` not being available in the `es6` lib target. Replaced `.includes()` with `.indexOf()` in `alertMatching.ts`, consistent with existing usage in the same file
+- Added `watchedClassIds` field to the `Alert` type. When set, `getWaitlistChangeType` skips `waitlist_changed` notifications for any class whose ID is not in the list, letting users target only the specific classes they have joined the waitlist for
+- Fixed TypeScript build error (TS2550): replaced `Array.prototype.includes` with `indexOf` in `alertMatching.ts` — `includes` is not available under the `es6` lib target
 
 ## 0.0.19
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.20
+
+- Fixed TypeScript build error (TS2550) caused by `Array.prototype.includes` not being available in the `es6` lib target. Replaced `.includes()` with `.indexOf()` in `alertMatching.ts`, consistent with existing usage in the same file
+
 ## 0.0.19
 
 - Added waitlist position alerts. Alerts with `waitlistAlerts` enabled now fire a `waitlist_changed` notification each time `waiting_count` changes for a matching class. Instructor, discipline, and schedule filters apply; the bookable-status threshold is ignored so the check works even when the class is full. Each distinct count value gets its own debounce key so every shift fires independently. The notification links to a dedicated in-app page (`/waitlist-alert`) rather than the class listing, prompting the user to check their email for the 2-hour acceptance window

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.20
 
-- Added `watchedClassIds` field to the `Alert` type. When set, `getWaitlistChangeType` skips `waitlist_changed` notifications for any class whose ID is not in the list, letting users target only the specific classes they have joined the waitlist for
+- Waitlist alerts can now be scoped to specific classes. When an alert has a class selection configured, `waitlist_changed` notifications only fire for those classes rather than every class matching the alert's filters
 
 ## 0.0.19
 

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,5 +1,5 @@
 name: Peloton Reservations
-version: "0.0.19"
+version: "0.0.20"
 image: ghcr.io/abbondanzo/peloton-reservations
 slug: peloton_reservations
 description: Polls Peloton studio schedules and sends class availability alerts

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Backend comparison service for sending notifications",
   "scripts": {
     "build": "tsc",

--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -363,6 +363,10 @@ export class Alerter implements DiffDelegate {
           body: `${count} ${count === 1 ? "person" : "people"} on the waitlist — ${instructorName} — ${className}${timeStr}`,
         };
       }
+      default: {
+        const _exhaustive: never = changeType;
+        throw new Error(`Unhandled change type: ${_exhaustive}`);
+      }
     }
   }
 

--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -363,10 +363,6 @@ export class Alerter implements DiffDelegate {
           body: `${count} ${count === 1 ? "person" : "people"} on the waitlist — ${instructorName} — ${className}${timeStr}`,
         };
       }
-      default: {
-        const _exhaustive: never = changeType;
-        throw new Error(`Unhandled change type: ${_exhaustive}`);
-      }
     }
   }
 

--- a/frontend/src/features/alerts/components/editor/AlertEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/AlertEditor.tsx
@@ -13,9 +13,10 @@ import { StepFilters } from "./StepFilters";
 import { StepIndicator } from "./StepIndicator";
 import { StepReview } from "./StepReview";
 import { StepSchedule } from "./StepSchedule";
+import { StepWaitlist } from "./StepWaitlist";
 import { useAlertEditorState } from "./useAlertEditorState";
 
-const STEPS = ["Basics", "Filters", "Schedule", "Review"];
+const STEPS = ["Basics", "Filters", "Schedule", "Waitlist", "Review"];
 
 const Wrapper = styled.div`
   display: flex;
@@ -144,6 +145,8 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
     setMaxStatus,
     waitlistAlerts,
     setWaitlistAlerts,
+    watchedClassIds,
+    setWatchedClassIds,
   } = useAlertEditorState(alertToEdit);
 
   const canGoNext = currentStep < STEPS.length - 1;
@@ -174,6 +177,9 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
       timeRanges,
       maxStatus,
       ...(waitlistAlerts ? { waitlistAlerts: true } : {}),
+      ...(waitlistAlerts && watchedClassIds !== null
+        ? { watchedClassIds }
+        : {}),
     };
 
     try {
@@ -199,6 +205,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
     timeRanges,
     maxStatus,
     waitlistAlerts,
+    watchedClassIds,
     onSave,
   ]);
 
@@ -229,8 +236,6 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
             onStudioChange={(id) => dispatch(setStudioId(id))}
             maxStatus={maxStatus}
             onStatusChange={setMaxStatus}
-            waitlistAlerts={waitlistAlerts}
-            onWaitlistAlertsChange={setWaitlistAlerts}
           />
         )}
         {currentStep === 1 && (
@@ -246,6 +251,18 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
           <StepSchedule timeRanges={timeRanges} setTimeRanges={setTimeRanges} />
         )}
         {currentStep === 3 && (
+          <StepWaitlist
+            studioId={selectedStudioId}
+            waitlistAlerts={waitlistAlerts}
+            onWaitlistAlertsChange={setWaitlistAlerts}
+            watchedClassIds={watchedClassIds}
+            onWatchedClassIdsChange={setWatchedClassIds}
+            selectedInstructors={selectedInstructors}
+            selectedDisciplines={selectedDisciplines}
+            timeRanges={timeRanges}
+          />
+        )}
+        {currentStep === 4 && (
           <StepReview
             name={name}
             studioId={selectedStudioId}
@@ -254,6 +271,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
             selectedDisciplines={selectedDisciplines}
             timeRanges={timeRanges}
             waitlistAlerts={waitlistAlerts}
+            watchedClassIds={watchedClassIds}
           />
         )}
       </StepContent>

--- a/frontend/src/features/alerts/components/editor/StepBasics.tsx
+++ b/frontend/src/features/alerts/components/editor/StepBasics.tsx
@@ -1,9 +1,7 @@
-import { useId } from "react";
 import { STUDIOS } from "shared";
 import styled from "styled-components";
 import type { BookableStatus } from "../../../filters/types/BookableStatus";
 import { mediaMobile } from "../../../theme/constants/queries";
-import { border, hover } from "../../../theme/constants/styles";
 import { TextInput } from "../../../theme/components/TextInput";
 import { OptionCard } from "./OptionCard";
 
@@ -38,47 +36,6 @@ const SectionSpacer = styled.div`
   ${mediaMobile`
     margin-top: 24px;
   `}
-`;
-
-const CheckCard = styled.label`
-  ${border}
-  ${hover}
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px;
-  cursor: pointer;
-  user-select: none;
-  transition:
-    border-color 0.15s,
-    background-color 0.15s;
-
-  &:has(input:checked) {
-    border-color: ${(props) => props.theme.colors.accent};
-    background-color: ${(props) => props.theme.colors.accent}0a;
-  }
-`;
-
-const CheckCardTextBlock = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-`;
-
-const CheckCardLabel = styled.span`
-  font-weight: 500;
-  color: ${(props) => props.theme.colors.main};
-`;
-
-const CheckCardHint = styled.span`
-  font-size: 12px;
-  color: ${(props) => props.theme.colors.secondary};
-`;
-
-const CheckCardInput = styled.input`
-  accent-color: ${(props) => props.theme.colors.accent};
-  flex-shrink: 0;
 `;
 
 interface StudioOption {
@@ -117,8 +74,6 @@ interface Props {
   onStudioChange: (studioId: string) => void;
   maxStatus: BookableStatus;
   onStatusChange: (status: BookableStatus) => void;
-  waitlistAlerts: boolean;
-  onWaitlistAlertsChange: (enabled: boolean) => void;
 }
 
 export const StepBasics = ({
@@ -128,10 +83,7 @@ export const StepBasics = ({
   onStudioChange,
   maxStatus,
   onStatusChange,
-  waitlistAlerts,
-  onWaitlistAlertsChange,
 }: Props) => {
-  const waitlistCheckId = useId();
   return (
     <div>
       <TextInput
@@ -179,30 +131,6 @@ export const StepBasics = ({
             />
           ))}
         </OptionsStack>
-      </Section>
-
-      <SectionSpacer />
-
-      <Section>
-        <Legend>Waitlist position alerts</Legend>
-        <Description>
-          Get a notification whenever the waitlist count changes — useful for
-          monitoring if it&apos;s your turn to accept a spot.
-        </Description>
-        <CheckCard htmlFor={waitlistCheckId}>
-          <CheckCardInput
-            type="checkbox"
-            id={waitlistCheckId}
-            checked={waitlistAlerts}
-            onChange={(e) => onWaitlistAlertsChange(e.target.checked)}
-          />
-          <CheckCardTextBlock>
-            <CheckCardLabel>Notify me when the waitlist count changes</CheckCardLabel>
-            <CheckCardHint>
-              Opens a prompt to check your email when the count shifts
-            </CheckCardHint>
-          </CheckCardTextBlock>
-        </CheckCard>
       </Section>
     </div>
   );

--- a/frontend/src/features/alerts/components/editor/StepReview.tsx
+++ b/frontend/src/features/alerts/components/editor/StepReview.tsx
@@ -113,6 +113,7 @@ interface Props {
   selectedDisciplines: Optional<string[]>;
   timeRanges: Optional<TimeRange>[];
   waitlistAlerts: boolean;
+  watchedClassIds: Optional<string[]>;
 }
 
 export const StepReview = ({
@@ -123,6 +124,7 @@ export const StepReview = ({
   selectedDisciplines,
   timeRanges,
   waitlistAlerts,
+  watchedClassIds,
 }: Props) => {
   const studio = STUDIOS[studioId];
   const enabledDays = DAY_NAMES.filter((_, i) => timeRanges[i]);
@@ -212,7 +214,15 @@ export const StepReview = ({
 
         <SummaryRow>
           <RowLabel>Waitlist alerts</RowLabel>
-          <RowValue>{waitlistAlerts ? "On" : "Off"}</RowValue>
+          <RowValue>
+            {!waitlistAlerts
+              ? "Off"
+              : watchedClassIds === null
+                ? "On — any matching class"
+                : watchedClassIds.length === 0
+                  ? "On — no classes selected"
+                  : `On — ${watchedClassIds.length} ${watchedClassIds.length === 1 ? "class" : "classes"} selected`}
+          </RowValue>
         </SummaryRow>
       </SummaryCard>
     </Section>

--- a/frontend/src/features/alerts/components/editor/StepWaitlist.tsx
+++ b/frontend/src/features/alerts/components/editor/StepWaitlist.tsx
@@ -1,0 +1,440 @@
+import { memo } from "react";
+import { STUDIOS, type TimeRange } from "shared";
+import styled from "styled-components";
+import { useGetClassesQuery } from "../../../class-list/services/pelotonApi";
+import type { Class } from "../../../class-list/types/Class";
+import { mediaMobile } from "../../../theme/constants/queries";
+import { border, hover } from "../../../theme/constants/styles";
+import { OptionCard } from "./OptionCard";
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const Section = styled.fieldset`
+  border: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const Legend = styled.legend`
+  font-weight: 600;
+  font-size: 18px;
+  color: ${(props) => props.theme.colors.main};
+  margin-bottom: 4px;
+`;
+
+const Description = styled.p`
+  color: ${(props) => props.theme.colors.secondary};
+  font-size: 14px;
+  margin: 0 0 16px;
+`;
+
+const OptionsStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const SectionSpacer = styled.div`
+  margin-top: 32px;
+
+  ${mediaMobile`
+    margin-top: 24px;
+  `}
+`;
+
+const ToggleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+`;
+
+const ToggleButton = styled.button<{ $active: boolean }>`
+  padding: 6px 16px;
+  border: 1px solid
+    ${(props) =>
+      props.$active ? props.theme.colors.accent : props.theme.borderColor};
+  border-radius: 20px;
+  background-color: ${(props) =>
+    props.$active ? `${props.theme.colors.accent}0f` : "transparent"};
+  color: ${(props) =>
+    props.$active ? props.theme.colors.accent : props.theme.colors.secondary};
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: ${(props) => props.theme.colors.accent};
+  }
+`;
+
+const ClassList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid ${(props) => props.theme.borderColor};
+  border-radius: ${(props) => props.theme.borderRadius};
+
+  ${mediaMobile`
+    max-height: 280px;
+  `}
+`;
+
+const ClassRow = styled.label<{ $checked: boolean }>`
+  ${border}
+  ${hover}
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s;
+  border-color: ${(props) =>
+    props.$checked ? props.theme.colors.accent : props.theme.borderColor};
+  background-color: ${(props) =>
+    props.$checked ? `${props.theme.colors.accent}0a` : "transparent"};
+`;
+
+const ClassCheckbox = styled.input`
+  accent-color: ${(props) => props.theme.colors.accent};
+  margin-top: 2px;
+  flex-shrink: 0;
+`;
+
+const ClassInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+`;
+
+const ClassTime = styled.span`
+  font-size: 13px;
+  font-weight: 500;
+  color: ${(props) => props.theme.colors.main};
+`;
+
+const ClassMeta = styled.span`
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.secondary};
+`;
+
+const StatusBadge = styled.span<{ $status: string }>`
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+  align-self: flex-start;
+  background-color: ${(props) => {
+    if (props.$status === "free") return `${props.theme.colors.accent}18`;
+    if (props.$status === "waitlist") return "#f59e0b18";
+    return `${props.theme.colors.secondarySurface}`;
+  }};
+  color: ${(props) => {
+    if (props.$status === "free") return props.theme.colors.accent;
+    if (props.$status === "waitlist") return "#b45309";
+    return props.theme.colors.secondary;
+  }};
+`;
+
+const StateText = styled.p`
+  color: ${(props) => props.theme.colors.secondary};
+  font-size: 14px;
+  padding: 20px;
+  text-align: center;
+  margin: 0;
+`;
+
+const RetryButton = styled.button`
+  border: none;
+  background: none;
+  color: ${(props) => props.theme.colors.accent};
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  text-decoration: underline;
+  padding: 0;
+`;
+
+const SelectedCount = styled.span`
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.secondary};
+  margin-left: auto;
+`;
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+function localMinuteOfDay(isoTimestamp: string, timezone: string): { day: number; minute: number } | null {
+  try {
+    const date = new Date(isoTimestamp);
+    const utcDate = new Date(date.toLocaleString("en-US", { timeZone: "UTC" }));
+    const tzDate = new Date(date.toLocaleString("en-US", { timeZone: timezone }));
+    const offset = utcDate.getTime() - tzDate.getTime();
+    date.setTime(date.getTime() - offset);
+    return { day: date.getDay(), minute: date.getHours() * 60 + date.getMinutes() };
+  } catch {
+    return null;
+  }
+}
+
+function formatClassTime(isoTimestamp: string, timezone: string): string {
+  try {
+    return new Date(isoTimestamp).toLocaleString("en-US", {
+      timeZone: timezone,
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return isoTimestamp;
+  }
+}
+
+function filterClasses(
+  classes: Class[],
+  instructors: Optional<string[]>,
+  disciplines: Optional<string[]>,
+  timeRanges: Optional<TimeRange>[],
+  studioId: string
+): Class[] {
+  const timezone = STUDIOS[studioId]?.timezone;
+  const now = Date.now();
+
+  return classes.filter((cls) => {
+    if (new Date(cls.start).getTime() <= now) return false;
+    if (instructors !== null && !instructors.includes(cls.instructor.id))
+      return false;
+    if (disciplines !== null && !disciplines.includes(cls.discipline.id))
+      return false;
+    if (timeRanges && timezone) {
+      const local = localMinuteOfDay(cls.start, timezone);
+      if (!local) return false;
+      const range = timeRanges[local.day];
+      if (!range) return false;
+      if (local.minute < range.startMin || local.minute > range.endMin)
+        return false;
+    }
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface ClassPickerProps {
+  studioId: string;
+  instructors: Optional<string[]>;
+  disciplines: Optional<string[]>;
+  timeRanges: Optional<TimeRange>[];
+  selectedIds: string[];
+  onToggle: (id: string) => void;
+}
+
+const ClassPicker = memo(({
+  studioId,
+  instructors,
+  disciplines,
+  timeRanges,
+  selectedIds,
+  onToggle,
+}: ClassPickerProps) => {
+  const query = useGetClassesQuery(studioId);
+  const timezone = STUDIOS[studioId]?.timezone ?? "UTC";
+
+  if (query.isLoading) {
+    return <StateText>Loading classes…</StateText>;
+  }
+  if (query.error) {
+    return (
+      <StateText>
+        Couldn&apos;t load classes.{" "}
+        <RetryButton type="button" onClick={query.refetch}>
+          Try again
+        </RetryButton>
+      </StateText>
+    );
+  }
+
+  const filtered = filterClasses(
+    query.currentData ?? [],
+    instructors,
+    disciplines,
+    timeRanges,
+    studioId
+  );
+
+  if (filtered.length === 0) {
+    return (
+      <StateText>No upcoming classes match your filters.</StateText>
+    );
+  }
+
+  return (
+    <ClassList role="group" aria-label="Classes">
+      {filtered.map((cls) => {
+        const checked = selectedIds.includes(cls.id);
+        const timeLabel = formatClassTime(cls.start, timezone);
+        const meta = [cls.instructor.name, cls.discipline.name]
+          .filter(Boolean)
+          .join(" · ");
+        const statusLabel =
+          cls.status === "free"
+            ? "Open"
+            : cls.status === "waitlist"
+              ? "Waitlist"
+              : "Full";
+        return (
+          <ClassRow
+            key={cls.id}
+            $checked={checked}
+            htmlFor={`cls-${cls.id}`}
+          >
+            <ClassCheckbox
+              type="checkbox"
+              id={`cls-${cls.id}`}
+              checked={checked}
+              onChange={() => onToggle(cls.id)}
+            />
+            <ClassInfo>
+              <ClassTime>{timeLabel}</ClassTime>
+              {meta && <ClassMeta>{meta}</ClassMeta>}
+            </ClassInfo>
+            <StatusBadge $status={cls.status}>{statusLabel}</StatusBadge>
+          </ClassRow>
+        );
+      })}
+    </ClassList>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// StepWaitlist
+// ---------------------------------------------------------------------------
+
+interface Props {
+  studioId: string;
+  waitlistAlerts: boolean;
+  onWaitlistAlertsChange: (enabled: boolean) => void;
+  /** null = any matching class; string[] = only these specific class IDs */
+  watchedClassIds: Optional<string[]>;
+  onWatchedClassIdsChange: (ids: Optional<string[]>) => void;
+  selectedInstructors: Optional<string[]>;
+  selectedDisciplines: Optional<string[]>;
+  timeRanges: Optional<TimeRange>[];
+}
+
+export const StepWaitlist = ({
+  studioId,
+  waitlistAlerts,
+  onWaitlistAlertsChange,
+  watchedClassIds,
+  onWatchedClassIdsChange,
+  selectedInstructors,
+  selectedDisciplines,
+  timeRanges,
+}: Props) => {
+  const toggleClass = (id: string) => {
+    const current = watchedClassIds ?? [];
+    onWatchedClassIdsChange(
+      current.includes(id) ? current.filter((x) => x !== id) : [...current, id]
+    );
+  };
+
+  const isSpecific = watchedClassIds !== null;
+  const selectedCount = watchedClassIds?.length ?? 0;
+
+  return (
+    <div>
+      <Section>
+        <Legend>Waitlist position alerts</Legend>
+        <Description>
+          Get a push notification whenever the waitlist count changes for a
+          matching class. Tap the notification to open a prompt reminding you
+          to check your email for the 2-hour acceptance window.
+        </Description>
+        <OptionsStack>
+          <OptionCard
+            name="waitlistAlerts"
+            value="off"
+            checked={!waitlistAlerts}
+            onChange={() => onWaitlistAlertsChange(false)}
+            label="Disabled"
+            hint="No waitlist count notifications"
+          />
+          <OptionCard
+            name="waitlistAlerts"
+            value="on"
+            checked={waitlistAlerts}
+            onChange={() => onWaitlistAlertsChange(true)}
+            label="Enabled"
+            hint="Notify me when the waitlist count changes"
+          />
+        </OptionsStack>
+      </Section>
+
+      {waitlistAlerts && (
+        <>
+          <SectionSpacer />
+          <Section>
+            <Legend>Which classes?</Legend>
+            <Description>
+              Notify for any class matching your filters, or pick specific ones
+              you&apos;ve already joined the waitlist for.
+            </Description>
+            <ToggleRow>
+              <ToggleButton
+                type="button"
+                $active={!isSpecific}
+                onClick={() => onWatchedClassIdsChange(null)}
+              >
+                Any matching class
+              </ToggleButton>
+              <ToggleButton
+                type="button"
+                $active={isSpecific}
+                onClick={() => {
+                  if (!isSpecific) onWatchedClassIdsChange([]);
+                }}
+              >
+                Specific classes
+              </ToggleButton>
+              {isSpecific && selectedCount > 0 && (
+                <SelectedCount>{selectedCount} selected</SelectedCount>
+              )}
+            </ToggleRow>
+
+            {isSpecific && (
+              <ClassPicker
+                studioId={studioId}
+                instructors={selectedInstructors}
+                disciplines={selectedDisciplines}
+                timeRanges={timeRanges}
+                selectedIds={watchedClassIds}
+                onToggle={toggleClass}
+              />
+            )}
+          </Section>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/alerts/components/editor/useAlertEditorState.ts
+++ b/frontend/src/features/alerts/components/editor/useAlertEditorState.ts
@@ -22,6 +22,8 @@ export interface AlertEditorState {
   setMaxStatus: (status: BookableStatus) => void;
   waitlistAlerts: boolean;
   setWaitlistAlerts: (enabled: boolean) => void;
+  watchedClassIds: Optional<string[]>;
+  setWatchedClassIds: (ids: Optional<string[]>) => void;
 }
 
 export const useAlertEditorState = (
@@ -54,6 +56,9 @@ export const useAlertEditorState = (
   const [waitlistAlerts, setWaitlistAlerts] = useState<boolean>(
     alertToEdit.waitlistAlerts ?? false
   );
+  const [watchedClassIds, setWatchedClassIds] = useState<Optional<string[]>>(
+    alertToEdit.watchedClassIds ?? null
+  );
 
   const lastStudioRef = useRef<string | undefined>(alertToEdit.studioId);
   useEffect(() => {
@@ -82,5 +87,7 @@ export const useAlertEditorState = (
     setMaxStatus,
     waitlistAlerts,
     setWaitlistAlerts,
+    watchedClassIds,
+    setWatchedClassIds,
   };
 };

--- a/shared/src/alertMatching.ts
+++ b/shared/src/alertMatching.ts
@@ -80,6 +80,12 @@ export const getWaitlistChangeType = (
   if (!checkDiscipline(newClass, alert)) return null;
   if (!checkInstructor(newClass, alert)) return null;
   if (!checkTimeRange(newClass, alert)) return null;
+  if (
+    alert.watchedClassIds &&
+    alert.watchedClassIds.length > 0 &&
+    !alert.watchedClassIds.includes(String(newClass.id))
+  )
+    return null;
   return "waitlist_changed";
 };
 

--- a/shared/src/alertMatching.ts
+++ b/shared/src/alertMatching.ts
@@ -83,7 +83,7 @@ export const getWaitlistChangeType = (
   if (
     alert.watchedClassIds &&
     alert.watchedClassIds.length > 0 &&
-    !alert.watchedClassIds.includes(String(newClass.id))
+    alert.watchedClassIds.indexOf(String(newClass.id)) === -1
   )
     return null;
   return "waitlist_changed";

--- a/shared/src/alerts.ts
+++ b/shared/src/alerts.ts
@@ -28,6 +28,8 @@ export interface Alert {
   timeRanges: Optional<TimeRange>[];
   studioId: string;
   waitlistAlerts?: boolean;
+  /** When set, waitlist_changed notifications only fire for these class IDs. */
+  watchedClassIds?: string[];
 }
 
 export interface AlertPreferences {


### PR DESCRIPTION
## Summary

- Replaces the simple waitlist alerts checkbox on Step 1 with a dedicated **Step 4 "Waitlist"** in the alert editor wizard (Basics → Filters → Schedule → **Waitlist** → Review)
- The step has two modes: **Any matching class** (fires for every class passing the alert's instructor / discipline / schedule filters) or **Specific classes** (fetches the live schedule, filters client-side, and renders each upcoming class as a checkbox so the user can mark exactly which ones they've joined the waitlist for)
- Selected class IDs are stored as `watchedClassIds: string[]` on the alert; the backend's `getWaitlistChangeType` skips a notification if the changed class is not in the list
- `StepReview` now shows `"Off"`, `"On — any matching class"`, or `"On — N classes selected"`

## Test plan

- [ ] Create a new alert and step through all 5 steps — confirm "Waitlist" appears between Schedule and Review
- [ ] On the Waitlist step, toggle Enabled/Disabled — confirm the class picker section shows/hides
- [ ] Toggle "Any matching class" → "Specific classes" — confirm the class list loads, is filtered by the alert's instructor/discipline/schedule settings, and only shows future classes
- [ ] Check a few classes, advance to Review — confirm the row shows "On — N classes selected"
- [ ] Save and re-open the alert for editing — confirm `watchedClassIds` and `waitlistAlerts` are restored correctly
- [ ] Confirm alerts with no `watchedClassIds` still fire `waitlist_changed` for any matching class (backend behaviour unchanged when field is absent)
- [ ] Confirm alerts with `watchedClassIds` set only fire for those specific class IDs

https://claude.ai/code/session_01JFfCK7izzqmzfSah3SCLRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFfCK7izzqmzfSah3SCLRA)_