### PR TITLE
[fix] Fix waitlist alert toggle not persisting disabled state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,27 @@ Both commit messages and PR titles must use the same semantic prefix format: `[f
 
 When running `gh pr create`, always include the prefix in the `--title` argument, e.g. `--title "[fix] Fix PWA pull-to-refresh spinner getting stuck"`.
 
+## Firebase Realtime Database — Write Semantics
+
+`update()` is a **partial write**: only keys present in the object are touched. Keys absent from the object are left unchanged in the database. This means:
+
+- **Never use conditional spreads to omit a field when you intend to clear it.** `...(flag ? { field: true } : {})` silently leaves a stale `true` in the DB when `flag` is `false`. Always include the field explicitly: `field: flag`.
+- **`null` deletes a key.** To remove an optional field from the database, set it to `null` in the update object. `undefined` behaves like the key is absent — it does NOT delete.
+- **`false` persists as `false`.** Boolean `false` is a valid stored value and will overwrite a previous `true`.
+
+When writing an edited document that has optional fields (`name?`, `watchedClassIds?`, etc.), explicitly null-out fields that are absent so stale values are cleared:
+
+```ts
+const data: Record<string, unknown> = {
+  ...alert,
+  name: alert.name ?? null,           // null → Firebase deletes the key
+  watchedClassIds: alert.watchedClassIds ?? null,
+};
+await update(ref(db, path), data);
+```
+
+See `editAlert.ts` for the canonical implementation of this pattern.
+
 ## Gotchas
 - Vite `preserveSymlinks: true` + pnpm causes duplicate React — fixed with `resolve.dedupe: ["react", "react-dom"]` in vite.config.ts
 - DisciplineIcon color matching: exact match first, then `.includes()` fallback (because "Outdoor Run" is substring of "Outdoor Run/Walk")

--- a/frontend/src/features/alerts/components/editor/AlertEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/AlertEditor.tsx
@@ -176,7 +176,7 @@ export const AlertEditor = ({ alertToEdit, onSave, onCancel }: Props) => {
       disciplines: selectedDisciplines,
       timeRanges,
       maxStatus,
-      ...(waitlistAlerts ? { waitlistAlerts: true } : {}),
+      waitlistAlerts,
       ...(waitlistAlerts && watchedClassIds !== null
         ? { watchedClassIds }
         : {}),

--- a/frontend/src/features/alerts/firebase/editAlert.ts
+++ b/frontend/src/features/alerts/firebase/editAlert.ts
@@ -11,5 +11,12 @@ export const editAlert = async (
   if (!db) {
     throw new Error("No Firebase database connection to use");
   }
-  await update(ref(db, PATHS.alert(userId, alert.id)), alert);
+  // Firebase uses null to delete a key; coerce absent optional fields to null
+  // so stale values are removed rather than left unchanged.
+  const data: Record<string, unknown> = {
+    ...alert,
+    name: alert.name ?? null,
+    watchedClassIds: alert.watchedClassIds ?? null,
+  };
+  await update(ref(db, PATHS.alert(userId, alert.id)), data);
 };


### PR DESCRIPTION
When saving an alert with waitlistAlerts=false, the conditional spread
produced {} leaving the old true value untouched in Firebase. Also
null-out absent optional fields in editAlert so Firebase clears stale
watchedClassIds and name values instead of leaving them behind.

https://claude.ai/code/session_01WvKzDdszZiKQY67nCW8tsL