### PR TITLE
[feat] Add pause all notifications and per-alert disable toggles

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.21
+
+- Alerts can now be individually disabled. A disabled alert is stored but never fires notifications until re-enabled
+- Added a global "pause all" preference. When enabled, all notifications are suppressed for the user regardless of individual alert settings
+
 ## 0.0.20
 
 - Waitlist alerts can now be scoped to specific classes. When an alert has a class selection configured, `waitlist_changed` notifications only fire for those classes rather than every class matching the alert's filters

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,5 +1,5 @@
 name: Peloton Reservations
-version: "0.0.20"
+version: "0.0.21"
 image: ghcr.io/abbondanzo/peloton-reservations
 slug: peloton_reservations
 description: Polls Peloton studio schedules and sends class availability alerts

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Backend comparison service for sending notifications",
   "scripts": {
     "build": "tsc",

--- a/backend/src/alerter.ts
+++ b/backend/src/alerter.ts
@@ -180,6 +180,13 @@ export class Alerter implements DiffDelegate {
     changeType: ChangeType,
     extraKey?: string
   ) {
+    if (this.alertPreferences[userId]?.pauseAll) {
+      logger.log(
+        `Suppressing ${changeType} for user ${userId}: all notifications paused`
+      );
+      return;
+    }
+
     const debounceKey = extraKey
       ? `${userId}:${classData.id}:${changeType}:${extraKey}`
       : `${userId}:${classData.id}:${changeType}`;
@@ -439,6 +446,7 @@ export class Alerter implements DiffDelegate {
         }
       }
       for (const alert of Object.values(alerts)) {
+        if (alert.disabled) continue;
         this.initializeUser(alert.studioId, userId);
         this.alertGroups[alert.studioId][userId].push(alert);
       }

--- a/frontend/src/features/alerts/components/atoms/Toggle.tsx
+++ b/frontend/src/features/alerts/components/atoms/Toggle.tsx
@@ -1,0 +1,74 @@
+import styled from "styled-components";
+
+const HiddenCheckbox = styled.input`
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+`;
+
+const Track = styled.div<{ $checked: boolean }>`
+  width: 40px;
+  height: 22px;
+  border-radius: 11px;
+  background-color: ${(props) =>
+    props.$checked ? props.theme.colors.accent : props.theme.colors.secondarySurface};
+  border: 1px solid
+    ${(props) =>
+      props.$checked ? props.theme.colors.accent : props.theme.borderColor};
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  position: relative;
+  flex-shrink: 0;
+`;
+
+const Thumb = styled.div<{ $checked: boolean }>`
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: white;
+  position: absolute;
+  top: 2px;
+  left: ${(props) => (props.$checked ? "20px" : "2px")};
+  transition: left 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+`;
+
+const Label = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  position: relative;
+`;
+
+interface Props {
+  id: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: string;
+  "aria-label"?: string;
+}
+
+export const Toggle = ({
+  id,
+  checked,
+  onChange,
+  label,
+  "aria-label": ariaLabel,
+}: Props) => (
+  <Label htmlFor={id}>
+    <HiddenCheckbox
+      id={id}
+      type="checkbox"
+      checked={checked}
+      aria-label={ariaLabel ?? label}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+    <Track $checked={checked}>
+      <Thumb $checked={checked} />
+    </Track>
+    {label && <span>{label}</span>}
+  </Label>
+);

--- a/frontend/src/features/alerts/components/editor/AlertPreferencesEditor.tsx
+++ b/frontend/src/features/alerts/components/editor/AlertPreferencesEditor.tsx
@@ -7,6 +7,7 @@ import { mediaMobile } from "../../../theme/constants/queries";
 import { border } from "../../../theme/constants/styles";
 import { AlertPreferencesContext } from "../../context/AlertPreferencesContext";
 import { setPreferences } from "../../firebase/setPreferences";
+import { Toggle } from "../atoms/Toggle";
 
 const Form = styled.form`
   display: flex;
@@ -113,6 +114,33 @@ const ErrorText = styled.p`
   padding: 16px;
 `;
 
+const PauseRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid ${(props) => props.theme.borderColor};
+  margin-bottom: 4px;
+`;
+
+const PauseInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const PauseLabel = styled.span`
+  font-size: 13px;
+  font-weight: 500;
+  color: ${(props) => props.theme.colors.main};
+`;
+
+const PauseHint = styled.span`
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.secondary};
+`;
+
 interface EditorProps {
   alertPreferences: Partial<AlertPreferences>;
 }
@@ -124,6 +152,7 @@ const Editor = ({ alertPreferences }: EditorProps) => {
   );
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const pauseAll = !!alertPreferences.pauseAll;
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -148,28 +177,52 @@ const Editor = ({ alertPreferences }: EditorProps) => {
     [userId, notificationDelayMin]
   );
 
+  const handleTogglePauseAll = useCallback(
+    async (checked: boolean) => {
+      if (!userId) return;
+      await setPreferences(userId, { pauseAll: !checked });
+    },
+    [userId]
+  );
+
   return (
-    <Form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <Label htmlFor="delay-input">Cooldown (minutes)</Label>
-        <Hint>Minimum delay between consecutive alert notifications</Hint>
-      </FieldGroup>
-      <InputRow>
-        <Input
-          id="delay-input"
-          type="number"
-          min={0}
-          value={notificationDelayMin}
-          onChange={(e) => {
-            const val = parseInt(e.target.value, 10);
-            if (!Number.isNaN(val)) setNotificationDelayMin(val);
-          }}
+    <>
+      <PauseRow>
+        <PauseInfo>
+          <PauseLabel>Enable all notifications</PauseLabel>
+          <PauseHint>
+            Globally pause or resume notifications for all alerts
+          </PauseHint>
+        </PauseInfo>
+        <Toggle
+          id="pause-all-toggle"
+          checked={!pauseAll}
+          onChange={handleTogglePauseAll}
+          aria-label={pauseAll ? "Resume all notifications" : "Pause all notifications"}
         />
-        <SaveButton type="submit" disabled={saving} $saved={saved}>
-          {saving ? "Saving…" : saved ? "Saved ✓" : "Save"}
-        </SaveButton>
-      </InputRow>
-    </Form>
+      </PauseRow>
+      <Form onSubmit={handleSubmit}>
+        <FieldGroup>
+          <Label htmlFor="delay-input">Cooldown (minutes)</Label>
+          <Hint>Minimum delay between consecutive alert notifications</Hint>
+        </FieldGroup>
+        <InputRow>
+          <Input
+            id="delay-input"
+            type="number"
+            min={0}
+            value={notificationDelayMin}
+            onChange={(e) => {
+              const val = parseInt(e.target.value, 10);
+              if (!Number.isNaN(val)) setNotificationDelayMin(val);
+            }}
+          />
+          <SaveButton type="submit" disabled={saving} $saved={saved}>
+            {saving ? "Saving…" : saved ? "Saved ✓" : "Save"}
+          </SaveButton>
+        </InputRow>
+      </Form>
+    </>
   );
 };
 

--- a/frontend/src/features/alerts/components/list/AlertsListItem.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsListItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { type Alert, STUDIOS } from "shared";
 import styled from "styled-components";
@@ -9,17 +9,20 @@ import { mediaMobile } from "../../../theme/constants/queries";
 import { border } from "../../../theme/constants/styles";
 import { DAY_NAMES } from "../../constants/days";
 import { deleteAlert } from "../../firebase/deleteAlert";
+import { editAlert } from "../../firebase/editAlert";
 import { isNotEmpty } from "../../../utils/optional";
 import {
   useGetInstructorsQuery,
   useGetDisciplinesQuery,
 } from "../../../class-list/services/pelotonApi";
 import { generateAlertTitle } from "../../operators/generateAlertTitle";
+import { Toggle } from "../atoms/Toggle";
 
-const Wrapper = styled.li`
+const Wrapper = styled.li<{ $disabled: boolean }>`
   ${border}
   padding: 16px;
   transition: box-shadow 0.15s;
+  opacity: ${(props) => (props.$disabled ? 0.55 : 1)};
 
   &:hover {
     box-shadow: rgba(0, 0, 0, 0.06) 0px 2px 12px;
@@ -191,6 +194,12 @@ interface Props {
 export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   const navigate = useNavigate();
   const userId = useAppSelector(selectUserId);
+  const isDisabled = !!alert.disabled;
+
+  const handleToggleDisabled = useCallback(() => {
+    if (!userId) return;
+    editAlert(userId, { ...alert, disabled: !isDisabled });
+  }, [userId, alert, isDisabled]);
   const { data: allInstructors } = useGetInstructorsQuery(alert.studioId);
   const { data: allDisciplines } = useGetDisciplinesQuery(alert.studioId);
 
@@ -249,7 +258,7 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   const statusInfo = formatStatus(alert.maxStatus);
 
   return (
-    <Wrapper>
+    <Wrapper $disabled={isDisabled}>
       <TopRow>
         <Info>
           <TitleRow>
@@ -281,6 +290,12 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
         </Info>
 
         <Actions>
+          <Toggle
+            id={`toggle-${alert.id}`}
+            checked={!isDisabled}
+            onChange={handleToggleDisabled}
+            aria-label={isDisabled ? "Enable alert" : "Disable alert"}
+          />
           <ActionButton
             type="button"
             onClick={() => navigate(alertsSimulationPath(alert.id))}

--- a/frontend/src/features/alerts/firebase/editAlert.ts
+++ b/frontend/src/features/alerts/firebase/editAlert.ts
@@ -17,6 +17,7 @@ export const editAlert = async (
     ...alert,
     name: alert.name ?? null,
     watchedClassIds: alert.watchedClassIds ?? null,
+    disabled: alert.disabled ?? null,
   };
   await update(ref(db, PATHS.alert(userId, alert.id)), data);
 };

--- a/shared/src/alerts.ts
+++ b/shared/src/alerts.ts
@@ -30,9 +30,13 @@ export interface Alert {
   waitlistAlerts?: boolean;
   /** When set, waitlist_changed notifications only fire for these class IDs. */
   watchedClassIds?: string[];
+  /** When true, the alert is stored but no notifications are sent. */
+  disabled?: boolean;
 }
 
 export interface AlertPreferences {
   lastUpdated: number;
   notificationDelayMin: number;
+  /** When true, all alert notifications are suppressed globally. */
+  pauseAll?: boolean;
 }


### PR DESCRIPTION
## Summary
Adds two new notification control features: a global "pause all" preference to suppress all alerts for a user, and per-alert disable toggles to individually disable specific alerts without deleting them.

## Changes

### Frontend
- **New Toggle component** (`Toggle.tsx`): Reusable styled toggle switch with smooth animations, accessible via hidden checkbox and aria-labels
- **Alert Preferences Editor**: Added "Enable all notifications" toggle at the top to control the global `pauseAll` preference
- **Alerts List Item**: Added per-alert disable toggle that visually dims disabled alerts (opacity 0.55)
- **EditAlert**: Updated to persist the `disabled` field with proper null-handling for optional fields

### Backend
- **Alerter**: Added early return in `notifyUser()` when `pauseAll` is true, suppressing all notifications regardless of individual alert settings
- **Alert initialization**: Skip disabled alerts when building alert groups during startup
- **Version bump**: 0.0.20 → 0.0.21 with changelog entry

### Shared Types
- `Alert.disabled?`: New optional boolean field to mark alerts as disabled
- `AlertPreferences.pauseAll?`: New optional boolean field for global notification pause

## Implementation Details
- Disabled alerts are stored in Firebase but never trigger notifications until re-enabled
- The global pause takes precedence over individual alert settings
- Toggle component uses styled-components with theme tokens for colors and transitions
- Proper Firebase write semantics: optional fields are explicitly set to `null` when absent to clear stale values

https://claude.ai/code/session_018ptNTytTnpz8yWNygpfDQN