### PR TITLE
[feat] Collapse alert actions into an overflow menu

### DIFF
--- a/frontend/src/features/alerts/components/list/AlertsListItem.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsListItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type Alert, STUDIOS } from "shared";
 import styled from "styled-components";
@@ -131,34 +131,74 @@ const Actions = styled.div`
   `}
 `;
 
-const ActionButton = styled.button`
-  padding: 6px 12px;
+
+const OverflowContainer = styled.div`
+  position: relative;
+  flex-shrink: 0;
+`;
+
+const OverflowButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
   border: 1px solid ${(props) => props.theme.borderColor};
   border-radius: ${(props) => props.theme.borderRadius};
   background: none;
-  font-family: inherit;
-  font-size: 12px;
-  color: ${(props) => props.theme.colors.secondary};
   cursor: pointer;
+  color: ${(props) => props.theme.colors.secondary};
   transition: all 0.15s;
-  white-space: nowrap;
+  padding: 0;
 
   &:hover {
     border-color: ${(props) => props.theme.colors.accent};
     color: ${(props) => props.theme.colors.accent};
   }
-
-  ${mediaMobile`
-    padding: 6px 10px;
-    font-size: 11px;
-  `}
 `;
 
-const DeleteButton = styled(ActionButton)`
+const OverflowMenuDropdown = styled.ul`
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: ${(props) => props.theme.colors.mainSurface};
+  border: 1px solid ${(props) => props.theme.borderColor};
+  border-radius: ${(props) => props.theme.borderRadius};
+  padding: 4px 0;
+  margin: 0;
+  list-style: none;
+  min-width: 130px;
+  z-index: 10;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+`;
+
+const OverflowMenuItem = styled.button`
+  display: block;
+  width: 100%;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 13px;
+  text-align: left;
+  color: ${(props) => props.theme.colors.main};
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+
   &:hover {
-    border-color: ${(props) => props.theme.colors.error};
-    color: ${(props) => props.theme.colors.error};
+    background: ${(props) => props.theme.colors.secondarySurface};
   }
+`;
+
+const DeleteMenuItem = styled(OverflowMenuItem)`
+  color: ${(props) => props.theme.colors.error};
+`;
+
+const MenuDivider = styled.li`
+  height: 1px;
+  background: ${(props) => props.theme.borderColor};
+  margin: 4px 0;
 `;
 
 const CreatedText = styled.span`
@@ -196,10 +236,33 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   const userId = useAppSelector(selectUserId);
   const isDisabled = !!alert.disabled;
 
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
   const handleToggleDisabled = useCallback(() => {
     if (!userId) return;
     editAlert(userId, { ...alert, disabled: !isDisabled });
   }, [userId, alert, isDisabled]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    const handleClick = (e: MouseEvent) => {
+      if (!(e.target instanceof Node)) return setMenuOpen(false);
+      if (!menuRef.current?.contains(e.target)) setMenuOpen(false);
+    };
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("keydown", handleKey);
+      document.addEventListener("click", handleClick, true);
+    }, 0);
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("click", handleClick, true);
+    };
+  }, [menuOpen]);
   const { data: allInstructors } = useGetInstructorsQuery(alert.studioId);
   const { data: allDisciplines } = useGetDisciplinesQuery(alert.studioId);
 
@@ -296,30 +359,74 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
             onChange={handleToggleDisabled}
             aria-label={isDisabled ? "Enable alert" : "Disable alert"}
           />
-          <ActionButton
-            type="button"
-            onClick={() => navigate(alertsSimulationPath(alert.id))}
-            aria-label="Test alert"
-          >
-            Test
-          </ActionButton>
-          <ActionButton type="button" onClick={() => onEdit(alert)} aria-label="Edit alert">
-            Edit
-          </ActionButton>
-          <ActionButton
-            type="button"
-            onClick={() => onDuplicate(alert)}
-            aria-label="Duplicate alert"
-          >
-            Duplicate
-          </ActionButton>
-          <DeleteButton
-            type="button"
-            onClick={() => userId && deleteAlert(userId, alert.id)}
-            aria-label="Delete alert"
-          >
-            Delete
-          </DeleteButton>
+          <OverflowContainer ref={menuRef}>
+            <OverflowButton
+              type="button"
+              aria-label="More options"
+              aria-expanded={menuOpen}
+              aria-haspopup="menu"
+              onClick={() => setMenuOpen((o) => !o)}
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <circle cx="8" cy="3" r="1.5" />
+                <circle cx="8" cy="8" r="1.5" />
+                <circle cx="8" cy="13" r="1.5" />
+              </svg>
+            </OverflowButton>
+            {menuOpen && (
+              <OverflowMenuDropdown role="menu">
+                <li>
+                  <OverflowMenuItem
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      navigate(alertsSimulationPath(alert.id));
+                    }}
+                  >
+                    Test
+                  </OverflowMenuItem>
+                </li>
+                <li>
+                  <OverflowMenuItem
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onEdit(alert);
+                    }}
+                  >
+                    Edit
+                  </OverflowMenuItem>
+                </li>
+                <li>
+                  <OverflowMenuItem
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onDuplicate(alert);
+                    }}
+                  >
+                    Duplicate
+                  </OverflowMenuItem>
+                </li>
+                <MenuDivider />
+                <li>
+                  <DeleteMenuItem
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      userId && deleteAlert(userId, alert.id);
+                    }}
+                  >
+                    Delete
+                  </DeleteMenuItem>
+                </li>
+              </OverflowMenuDropdown>
+            )}
+          </OverflowContainer>
         </Actions>
       </TopRow>
     </Wrapper>

--- a/frontend/src/features/alerts/components/list/AlertsListItem.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsListItem.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { type Alert, STUDIOS } from "shared";
 import styled from "styled-components";
@@ -157,10 +158,10 @@ const OverflowButton = styled.button`
   }
 `;
 
-const OverflowMenuDropdown = styled.ul`
-  position: absolute;
-  right: 0;
-  top: calc(100% + 4px);
+const OverflowMenuDropdown = styled.ul<{ $top: number; $right: number }>`
+  position: fixed;
+  top: ${(props) => props.$top}px;
+  right: ${(props) => props.$right}px;
   background: ${(props) => props.theme.colors.mainSurface};
   border: 1px solid ${(props) => props.theme.borderColor};
   border-radius: ${(props) => props.theme.borderRadius};
@@ -168,7 +169,7 @@ const OverflowMenuDropdown = styled.ul`
   margin: 0;
   list-style: none;
   min-width: 130px;
-  z-index: 10;
+  z-index: 1000;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
 `;
 
@@ -237,12 +238,23 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   const isDisabled = !!alert.disabled;
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuCoords, setMenuCoords] = useState({ top: 0, right: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
 
   const handleToggleDisabled = useCallback(() => {
     if (!userId) return;
     editAlert(userId, { ...alert, disabled: !isDisabled });
   }, [userId, alert, isDisabled]);
+
+  useLayoutEffect(() => {
+    if (!menuOpen || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setMenuCoords({
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+    });
+  }, [menuOpen]);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -251,7 +263,11 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
     };
     const handleClick = (e: MouseEvent) => {
       if (!(e.target instanceof Node)) return setMenuOpen(false);
-      if (!menuRef.current?.contains(e.target)) setMenuOpen(false);
+      if (
+        !buttonRef.current?.contains(e.target) &&
+        !dropdownRef.current?.contains(e.target)
+      )
+        setMenuOpen(false);
     };
     const timeoutId = setTimeout(() => {
       document.addEventListener("keydown", handleKey);
@@ -359,8 +375,9 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
             onChange={handleToggleDisabled}
             aria-label={isDisabled ? "Enable alert" : "Disable alert"}
           />
-          <OverflowContainer ref={menuRef}>
+          <OverflowContainer>
             <OverflowButton
+              ref={buttonRef}
               type="button"
               aria-label="More options"
               aria-expanded={menuOpen}
@@ -373,59 +390,66 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
                 <circle cx="8" cy="13" r="1.5" />
               </svg>
             </OverflowButton>
-            {menuOpen && (
-              <OverflowMenuDropdown role="menu">
-                <li>
-                  <OverflowMenuItem
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      navigate(alertsSimulationPath(alert.id));
-                    }}
-                  >
-                    Test
-                  </OverflowMenuItem>
-                </li>
-                <li>
-                  <OverflowMenuItem
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      onEdit(alert);
-                    }}
-                  >
-                    Edit
-                  </OverflowMenuItem>
-                </li>
-                <li>
-                  <OverflowMenuItem
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      onDuplicate(alert);
-                    }}
-                  >
-                    Duplicate
-                  </OverflowMenuItem>
-                </li>
-                <MenuDivider />
-                <li>
-                  <DeleteMenuItem
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      userId && deleteAlert(userId, alert.id);
-                    }}
-                  >
-                    Delete
-                  </DeleteMenuItem>
-                </li>
-              </OverflowMenuDropdown>
-            )}
+            {menuOpen &&
+              createPortal(
+                <OverflowMenuDropdown
+                  ref={dropdownRef}
+                  role="menu"
+                  $top={menuCoords.top}
+                  $right={menuCoords.right}
+                >
+                  <li>
+                    <OverflowMenuItem
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        navigate(alertsSimulationPath(alert.id));
+                      }}
+                    >
+                      Test
+                    </OverflowMenuItem>
+                  </li>
+                  <li>
+                    <OverflowMenuItem
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onEdit(alert);
+                      }}
+                    >
+                      Edit
+                    </OverflowMenuItem>
+                  </li>
+                  <li>
+                    <OverflowMenuItem
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onDuplicate(alert);
+                      }}
+                    >
+                      Duplicate
+                    </OverflowMenuItem>
+                  </li>
+                  <MenuDivider />
+                  <li>
+                    <DeleteMenuItem
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        userId && deleteAlert(userId, alert.id);
+                      }}
+                    >
+                      Delete
+                    </DeleteMenuItem>
+                  </li>
+                </OverflowMenuDropdown>,
+                document.body
+              )}
           </OverflowContainer>
         </Actions>
       </TopRow>

--- a/frontend/src/features/alerts/components/list/AlertsListItem.tsx
+++ b/frontend/src/features/alerts/components/list/AlertsListItem.tsx
@@ -202,6 +202,60 @@ const MenuDivider = styled.li`
   margin: 4px 0;
 `;
 
+const DeleteConfirm = styled.div`
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const DeleteConfirmText = styled.p`
+  margin: 0;
+  font-size: 13px;
+  color: ${(props) => props.theme.colors.main};
+  white-space: nowrap;
+`;
+
+const DeleteConfirmButtons = styled.div`
+  display: flex;
+  gap: 6px;
+`;
+
+const DeleteConfirmCancel = styled.button`
+  flex: 1;
+  padding: 5px 10px;
+  border: 1px solid ${(props) => props.theme.borderColor};
+  border-radius: ${(props) => props.theme.borderRadius};
+  background: none;
+  font-family: inherit;
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.secondary};
+  cursor: pointer;
+  transition: all 0.1s;
+
+  &:hover {
+    border-color: ${(props) => props.theme.colors.main};
+    color: ${(props) => props.theme.colors.main};
+  }
+`;
+
+const DeleteConfirmSubmit = styled.button`
+  flex: 1;
+  padding: 5px 10px;
+  border: 1px solid ${(props) => props.theme.colors.error};
+  border-radius: ${(props) => props.theme.borderRadius};
+  background: ${(props) => props.theme.colors.error};
+  font-family: inherit;
+  font-size: 12px;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.1s;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;
+
 const CreatedText = styled.span`
   font-size: 11px;
   color: ${(props) => props.theme.colors.secondary};
@@ -238,6 +292,7 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   const isDisabled = !!alert.disabled;
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState(false);
   const [menuCoords, setMenuCoords] = useState({ top: 0, right: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLUListElement>(null);
@@ -246,6 +301,11 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
     if (!userId) return;
     editAlert(userId, { ...alert, disabled: !isDisabled });
   }, [userId, alert, isDisabled]);
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false);
+    setPendingDelete(false);
+  }, []);
 
   useLayoutEffect(() => {
     if (!menuOpen || !buttonRef.current) return;
@@ -259,15 +319,15 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
   useEffect(() => {
     if (!menuOpen) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setMenuOpen(false);
+      if (e.key === "Escape") closeMenu();
     };
     const handleClick = (e: MouseEvent) => {
-      if (!(e.target instanceof Node)) return setMenuOpen(false);
+      if (!(e.target instanceof Node)) return closeMenu();
       if (
         !buttonRef.current?.contains(e.target) &&
         !dropdownRef.current?.contains(e.target)
       )
-        setMenuOpen(false);
+        closeMenu();
     };
     const timeoutId = setTimeout(() => {
       document.addEventListener("keydown", handleKey);
@@ -403,7 +463,7 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
                       type="button"
                       role="menuitem"
                       onClick={() => {
-                        setMenuOpen(false);
+                        closeMenu();
                         navigate(alertsSimulationPath(alert.id));
                       }}
                     >
@@ -415,7 +475,7 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
                       type="button"
                       role="menuitem"
                       onClick={() => {
-                        setMenuOpen(false);
+                        closeMenu();
                         onEdit(alert);
                       }}
                     >
@@ -427,7 +487,7 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
                       type="button"
                       role="menuitem"
                       onClick={() => {
-                        setMenuOpen(false);
+                        closeMenu();
                         onDuplicate(alert);
                       }}
                     >
@@ -435,18 +495,40 @@ export const AlertsListItem = memo(({ alert, onDuplicate, onEdit }: Props) => {
                     </OverflowMenuItem>
                   </li>
                   <MenuDivider />
-                  <li>
-                    <DeleteMenuItem
-                      type="button"
-                      role="menuitem"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        userId && deleteAlert(userId, alert.id);
-                      }}
-                    >
-                      Delete
-                    </DeleteMenuItem>
-                  </li>
+                  {pendingDelete ? (
+                    <li>
+                      <DeleteConfirm>
+                        <DeleteConfirmText>Delete this alert?</DeleteConfirmText>
+                        <DeleteConfirmButtons>
+                          <DeleteConfirmCancel
+                            type="button"
+                            onClick={() => setPendingDelete(false)}
+                          >
+                            Cancel
+                          </DeleteConfirmCancel>
+                          <DeleteConfirmSubmit
+                            type="button"
+                            onClick={() => {
+                              closeMenu();
+                              userId && deleteAlert(userId, alert.id);
+                            }}
+                          >
+                            Delete
+                          </DeleteConfirmSubmit>
+                        </DeleteConfirmButtons>
+                      </DeleteConfirm>
+                    </li>
+                  ) : (
+                    <li>
+                      <DeleteMenuItem
+                        type="button"
+                        role="menuitem"
+                        onClick={() => setPendingDelete(true)}
+                      >
+                        Delete
+                      </DeleteMenuItem>
+                    </li>
+                  )}
                 </OverflowMenuDropdown>,
                 document.body
               )}


### PR DESCRIPTION
Test, Edit, Duplicate, and Delete are now in a vertical-dots dropdown
next to the toggle, reducing visual clutter as the option list grows.
The menu closes on outside click or Escape key.

https://claude.ai/code/session_01WGXoogRynMkXK9ubbB9uBm